### PR TITLE
Operation solar pressurisation is a go.

### DIFF
--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -735,14 +735,13 @@
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
 "agM" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/machinery/door/airlock/external/glass{
 	cyclelinkeddir = 2;
 	req_access = 13;
 	req_access_txt = "13;65"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/solars/port/aft)
 "agO" = (
 /obj/machinery/requests_console/directional/north{
@@ -5929,14 +5928,13 @@
 /turf/open/floor/carpet/purple,
 /area/service/bar)
 "aXM" = (
-/obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/stripes/red/box,
 /obj/machinery/door/airlock/external/glass{
 	cyclelinkeddir = 2;
 	req_access = 13;
 	req_access_txt = "13"
 	},
-/turf/open/space,
+/turf/open/floor/plating,
 /area/solars/starboard)
 "aXN" = (
 /turf/closed/wall,
@@ -39681,13 +39679,12 @@
 /turf/open/floor/iron/half,
 /area/hallway/primary/aft)
 "hQV" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay SMES Access";
 	req_access_txt = "10;11;12;45"
 	},
-/turf/open/space,
+/turf/open/floor/plating,
 /area/solars/aux/starboard)
 "hQX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -41444,6 +41441,9 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"ikv" = (
+/turf/open/floor/plating,
+/area/solars/starboard/aft)
 "ikw" = (
 /obj/structure/chair{
 	dir = 8
@@ -42627,6 +42627,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"iyv" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/solars/starboard/fore)
 "iyI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -44476,14 +44480,13 @@
 	},
 /area/hallway/secondary/entry)
 "iUd" = (
-/obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/stripes/red/box,
 /obj/machinery/door/airlock/external/glass{
 	cyclelinkeddir = 2;
 	req_access = 13;
 	req_access_txt = "13"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/solars/port/fore)
 "iUk" = (
 /obj/structure/cable,
@@ -49901,14 +49904,13 @@
 /turf/closed/wall,
 /area/science/robotics/mechbay)
 "kaT" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/machinery/door/airlock/external/glass{
 	cyclelinkeddir = 2;
 	req_access = 13;
 	req_access_txt = "13"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/solars/port)
 "kaX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -50833,6 +50835,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"kkI" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/solars/aux/starboard)
 "kkV" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/item/reagent_containers/glass/bucket,
@@ -65209,6 +65215,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"nqJ" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/solars/port)
 "nqR" = (
 /obj/effect/turf_decal/tile{
 	dir = 1
@@ -78042,6 +78052,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"qez" = (
+/obj/machinery/door/airlock/external{
+	cyclelinkeddir = 4;
+	name = "Solar Maintenance";
+	req_access = null;
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/red/box,
+/turf/open/floor/plating,
+/area/solars/aux/starboard)
 "qeA" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -84728,7 +84749,6 @@
 /turf/open/floor/iron/grimy,
 /area/security/office)
 "rEl" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "A.I Solar Access";
@@ -84737,7 +84757,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/solars/port/aft)
 "rEm" = (
 /obj/effect/turf_decal/stripes/box,
@@ -94313,14 +94333,13 @@
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai)
 "tQh" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Science SMES Access";
 	req_access_txt = "10;11;12"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/solars/starboard/aft)
 "tQj" = (
 /obj/structure/cable,
@@ -103948,14 +103967,13 @@
 /turf/closed/wall,
 /area/hallway/primary/starboard)
 "vTq" = (
-/obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/stripes/red/box,
 /obj/machinery/door/airlock/external/glass{
 	cyclelinkeddir = 2;
 	req_access = 13;
 	req_access_txt = "13"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/solars/starboard/aft)
 "vTs" = (
 /obj/effect/turf_decal/stripes/line{
@@ -109156,6 +109174,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/morgue)
+"xgM" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/solars/port/aft)
 "xgO" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -110051,6 +110073,10 @@
 "xpI" = (
 /turf/open/floor/engine,
 /area/hallway/secondary/construction/engineering)
+"xpK" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/solars/starboard/aft)
 "xpL" = (
 /obj/effect/turf_decal/siding/green,
 /obj/structure/table/reinforced,
@@ -113562,14 +113588,13 @@
 /turf/open/floor/iron/large,
 /area/hallway/primary/starboard)
 "xXE" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/door/airlock/external{
 	cyclelinkeddir = 4;
 	name = "Solar Maintenance";
 	req_access = null;
 	req_access_txt = "10; 13"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/solars/starboard/fore)
 "xXL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -143828,7 +143853,7 @@ ccW
 aaa
 cFp
 wTi
-jUp
+xpK
 wTi
 jeV
 jeV
@@ -144085,7 +144110,7 @@ cFp
 cFp
 nyF
 wTi
-jUp
+xpK
 wTi
 iDR
 iDR
@@ -144341,8 +144366,8 @@ bhv
 cFp
 eIK
 vTq
-eIK
-jyC
+ikv
+ikv
 wTi
 jdZ
 jdZ
@@ -157187,7 +157212,7 @@ cFp
 cFp
 cFp
 euu
-nTI
+iyv
 euu
 cFp
 cFp
@@ -157444,7 +157469,7 @@ cFp
 bhv
 cFp
 euu
-nTI
+iyv
 euu
 cFp
 bhv
@@ -157564,8 +157589,8 @@ xMf
 xMf
 cFp
 fso
-kVR
-kVR
+xgM
+xgM
 fso
 cFp
 bhv
@@ -158078,7 +158103,7 @@ xMf
 xMf
 cFp
 agq
-kVR
+xgM
 agq
 kVR
 iNK
@@ -159943,8 +159968,8 @@ qGV
 nLh
 lyM
 lyM
-nLh
-lyM
+qez
+kkI
 hQV
 njI
 mIe
@@ -163512,8 +163537,8 @@ wZT
 kmW
 uKK
 aiR
-jOL
-jOL
+nqJ
+nqJ
 kaT
 jOL
 jOL


### PR DESCRIPTION
## About The Pull Request

Replaces the cat walks on all solar control rooms with normal floors, to reduce depressurisation early in the round.

There are other issues with solars like how they are linked but I'll do that once I learn how to use strongdmm better.

## Why It's Good For The Game

All other maps use this so that solars don't depressurise their solar control room, so it should be mirrored here. 

## Changelog
:cl:
fix: floors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
