### PR TITLE
Slight kitchen tweaks

### DIFF
--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -11788,6 +11788,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"bVH" = (
+/obj/structure/sign/directions/science,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/service/kitchen)
 "bVK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron,
@@ -39599,7 +39605,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/hallway/primary/port)
+/area/service/kitchen)
 "hQa" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -54433,6 +54439,11 @@
 	dir = 8
 	},
 /area/hallway/primary/fore)
+"kXC" = (
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/service/kitchen)
 "kXO" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid/airless,
@@ -69265,7 +69276,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/hallway/primary/port)
+/area/service/kitchen)
 "okK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -90968,7 +90979,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/hallway/primary/port)
+/area/service/kitchen)
 "sZO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -111887,6 +111898,14 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"xGf" = (
+/obj/structure/sign/directions/security{
+	dir = 1
+	},
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/service/kitchen)
 "xGi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -130191,9 +130210,9 @@ wtf
 tEM
 ipR
 tEM
-jtZ
-pFf
-pFf
+bVH
+kXC
+kXC
 uOo
 uOo
 bRk
@@ -130448,8 +130467,8 @@ xDN
 tEM
 qOr
 tEM
-cFJ
-pFf
+xGf
+kXC
 sZM
 fEJ
 uFr

--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -47506,6 +47506,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"jCz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/iron/white,
+/area/service/kitchen)
 "jCD" = (
 /obj/item/storage/box/evidence,
 /obj/structure/table,
@@ -73733,6 +73744,7 @@
 /obj/item/reagent_containers/food/condiment/enzyme{
 	pixel_y = 5
 	},
+/obj/item/food/mint,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "phm" = (
@@ -130727,7 +130739,7 @@ tEM
 oky
 hPY
 sZM
-uLj
+jCz
 uFr
 uFr
 uFr
@@ -133045,7 +133057,7 @@ bRk
 rgi
 uLj
 uLj
-uLj
+jCz
 jdA
 bRk
 bRk

--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -6103,9 +6103,9 @@
 /area/service/hydroponics/garden)
 "aYx" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
 /obj/item/clothing/head/chefhat,
 /obj/effect/turf_decal/tile/red,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "aYD" = (
@@ -30093,14 +30093,10 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fEJ" = (
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/item/reagent_containers/food/condiment/milk,
 /obj/effect/turf_decal/tile/red,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "fEN" = (
@@ -44516,14 +44512,14 @@
 "iUp" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/red,
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/flour,
 /obj/machinery/requests_console/directional/south,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/rice,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/papersack{
+	icon_state = "paperbag_NanotrasenStandard_closed"
+	},
+/obj/item/storage/box/papersack{
+	icon_state = "paperbag_NanotrasenStandard_closed"
+	},
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "iUy" = (
@@ -47728,8 +47724,8 @@
 	pixel_x = -26;
 	req_access_txt = "28"
 	},
-/obj/item/kitchen/rollingpin,
 /obj/effect/turf_decal/tile/red,
+/obj/item/holosign_creator/robot_seat/restaurant,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "jEV" = (
@@ -49408,7 +49404,6 @@
 /area/hallway/primary/upper)
 "jVN" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
 /obj/item/clothing/head/chefhat,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/button/door/directional/south{
@@ -58176,13 +58171,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lPb" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
 /obj/effect/turf_decal/tile/red,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 5
-	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "lPo" = (
@@ -73695,8 +73685,10 @@
 "pgW" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
 /obj/effect/turf_decal/tile/red,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 5
+	},
 /obj/item/reagent_containers/food/condiment/enzyme{
 	pixel_y = 5
 	},
@@ -75878,6 +75870,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"pDo" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/turf/open/floor/iron/white,
+/area/service/kitchen)
 "pDp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93604,24 +93612,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tIX" = (
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 5
-	},
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed"
-	},
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/camera{
 	c_tag = "Service- Kitchen 4 ";
@@ -93630,6 +93620,7 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "tJe" = (
@@ -96429,19 +96420,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "ung" = (
+/obj/effect/turf_decal/tile/red,
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
+/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
+/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "uno" = (
@@ -103331,7 +103313,6 @@
 "vMp" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red,
-/obj/item/holosign_creator/robot_seat/restaurant,
 /obj/item/storage/box/papersack{
 	icon_state = "paperbag_NanotrasenStandard_closed"
 	},
@@ -130458,8 +130439,8 @@ pFf
 sZM
 uLj
 uFr
-uFr
-uFr
+fEJ
+ung
 evj
 bKk
 jUs
@@ -131225,7 +131206,7 @@ tEM
 sYQ
 tEM
 uOo
-fEJ
+uFr
 uFr
 uFr
 uFr
@@ -133031,8 +133012,8 @@ bRk
 rgi
 uLj
 uLj
-ung
-klL
+uLj
+pDo
 bRk
 bRk
 bRk

--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -4772,6 +4772,13 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"aPm" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table/reinforced,
+/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
+/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
+/turf/open/floor/iron/white,
+/area/service/kitchen)
 "aPp" = (
 /obj/effect/loot_site_spawner,
 /obj/structure/lattice,
@@ -30093,10 +30100,17 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fEJ" = (
-/obj/effect/turf_decal/tile/red,
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "fEN" = (
@@ -45408,6 +45422,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/service/bar/atrium)
+"jdA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/turf/open/floor/iron/white,
+/area/service/kitchen)
 "jdR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -75870,22 +75900,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"pDo" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/turf/open/floor/iron/white,
-/area/service/kitchen)
 "pDp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -96422,8 +96436,8 @@
 "ung" = (
 /obj/effect/turf_decal/tile/red,
 /obj/structure/table/reinforced,
-/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
-/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "uno" = (
@@ -129920,7 +129934,7 @@ pFf
 tEM
 jUj
 xRe
-pFf
+cny
 pFf
 pFf
 jBR
@@ -130177,7 +130191,7 @@ wtf
 tEM
 ipR
 tEM
-syv
+jtZ
 pFf
 pFf
 uOo
@@ -130434,13 +130448,13 @@ xDN
 tEM
 qOr
 tEM
-pFf
+cFJ
 pFf
 sZM
-uLj
-uFr
 fEJ
+uFr
 ung
+aPm
 evj
 bKk
 jUs
@@ -133013,7 +133027,7 @@ rgi
 uLj
 uLj
 uLj
-pDo
+jdA
 bRk
 bRk
 bRk

--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -6380,7 +6380,6 @@
 /area/service/kitchen)
 "aZB" = (
 /obj/machinery/chem_master/condimaster,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
@@ -8853,7 +8852,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/service/kitchen)
 "bmm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -10909,13 +10908,10 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "bJz" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/white,
-/area/service/kitchen)
+/obj/structure/cable,
+/obj,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bJY" = (
 /obj/structure/sink{
 	pixel_y = 22
@@ -10942,6 +10938,14 @@
 	},
 /turf/open/floor/plating/rust,
 /area/commons/vacant_room)
+"bKk" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/service/kitchen)
 "bKl" = (
 /obj/structure/cable,
 /turf/open/floor/iron/large,
@@ -24490,7 +24494,10 @@
 /turf/open/floor/plating,
 /area/commons/vacant_room)
 "evj" = (
-/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/computer/chef_order{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "evx" = (
@@ -30086,25 +30093,14 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fEJ" = (
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 5
-	},
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed"
-	},
 /obj/item/reagent_containers/food/condiment/soymilk,
 /obj/item/reagent_containers/food/condiment/milk,
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed"
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "fEN" = (
@@ -44522,19 +44518,12 @@
 /obj/effect/turf_decal/tile/red,
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/flour,
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed"
-	},
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/soymilk,
-/obj/item/storage/box/papersack{
-	icon_state = "paperbag_NanotrasenStandard_closed"
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/flour,
 /obj/machinery/requests_console/directional/south,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/rice,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "iUy" = (
@@ -49430,7 +49419,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "jVW" = (
@@ -51418,6 +51406,15 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"kqL" = (
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	name = "Kitchen Delivery";
+	req_access_txt = "28"
+	},
+/turf/open/floor/iron/white,
+/area/service/kitchen)
 "kqO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/blue{
@@ -58183,6 +58180,9 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/book/granter/crafting_recipe/cooking_sweets_101,
 /obj/effect/turf_decal/tile/red,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "lPo" = (
@@ -73695,9 +73695,11 @@
 "pgW" = (
 /obj/structure/table/reinforced,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/item/kitchen/knife,
 /obj/item/book/granter/crafting_recipe/cooking_sweets_101,
 /obj/effect/turf_decal/tile/red,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "phm" = (
@@ -96426,6 +96428,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"ung" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/turf/open/floor/iron/white,
+/area/service/kitchen)
 "uno" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera{
@@ -103314,6 +103332,12 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red,
 /obj/item/holosign_creator/robot_seat/restaurant,
+/obj/item/storage/box/papersack{
+	icon_state = "paperbag_NanotrasenStandard_closed"
+	},
+/obj/item/storage/box/papersack{
+	icon_state = "paperbag_NanotrasenStandard_closed"
+	},
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "vMq" = (
@@ -113989,12 +114013,7 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "ydj" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/door/window/eastleft{
-	dir = 8;
-	name = "Kitchen Delivery";
-	req_access_txt = "28"
-	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "ydm" = (
@@ -127355,7 +127374,7 @@ giw
 vAQ
 vht
 oaN
-vht
+bJz
 lOJ
 uhI
 lOJ
@@ -129920,7 +129939,7 @@ pFf
 tEM
 jUj
 xRe
-jtZ
+pFf
 pFf
 pFf
 jBR
@@ -130177,15 +130196,15 @@ wtf
 tEM
 ipR
 tEM
-cny
+syv
 pFf
 pFf
 uOo
-evj
-rgi
-uLj
-uLj
-uLj
+uOo
+bRk
+bRk
+bRk
+ydj
 bRk
 uOo
 koZ
@@ -130434,15 +130453,15 @@ xDN
 tEM
 qOr
 tEM
-cFJ
 pFf
 pFf
-uOo
-bJz
+sZM
+uLj
 uFr
 uFr
 uFr
-uFr
+evj
+bKk
 jUs
 fIM
 dTP
@@ -130695,11 +130714,11 @@ oky
 hPY
 sZM
 uLj
-ydj
 uFr
 uFr
 uFr
 uFr
+kqL
 kAA
 uFr
 rpQ
@@ -133012,7 +133031,7 @@ bRk
 rgi
 uLj
 uLj
-uLj
+ung
 klL
 bRk
 bRk


### PR DESCRIPTION
## About The Pull Request

I have changed the left hand side of the kitchen so that the chefs only have two counters. Three counters are way too many for them to manage. 

The kitchen express console has been added for convenience.

I changed some item placement (universal enzyme, counter items etc) so that it's resembles other maps.

The items in the fridges have been separated so that one has milk, one has the rice, flour and sugar bags and the meat fridge in the freezer.

![image](https://user-images.githubusercontent.com/71316563/124332955-c14dc000-db8a-11eb-8cc0-aa2bafdb4173.png)


## Why It's Good For The Game

The counter changes mean they don't have to make obscene amounts of food or worry about tiders from 3 directions. 

The item changes are just to resemble other maps.

## Changelog
:cl:
add: Express consoles
del: Counters
qol: Item placement
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
