### PR TITLE
Removes mediborg arcade machines

### DIFF
--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -9316,6 +9316,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/purple,
 /area/service/bar)
+"brA" = (
+/obj/item/storage/secure/safe/caps_spare,
+/turf/closed/wall/r_wall,
+/area/command/meeting_room/council)
 "bsc" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 9
@@ -59722,6 +59726,10 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 6
 	},
+/obj/item/paper{
+	info = "Special thanks to Eibon working hard to re-make EosStation. -Anonymous";
+	name = "Hidden message"
+	},
 /turf/open/floor/carpet/stellar,
 /area/commons/vacant_room)
 "mwC" = (
@@ -60054,9 +60062,6 @@
 /area/science/storage)
 "mAn" = (
 /obj/machinery/photocopier,
-/obj/item/storage/secure/safe/caps_spare{
-	pixel_x = -23
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -147993,7 +147998,7 @@ aaw
 pnT
 wvU
 urp
-hHW
+brA
 evC
 eKT
 xvk

--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -4794,6 +4794,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"aQT" = (
+/obj/structure/table/wood,
+/turf/open/floor/plating/rust,
+/area/commons/vacant_room)
 "aRd" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -9316,10 +9320,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/purple,
 /area/service/bar)
-"brA" = (
-/obj/item/storage/secure/safe/caps_spare,
-/turf/closed/wall/r_wall,
-/area/command/meeting_room/council)
 "bsc" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 9
@@ -23276,10 +23276,9 @@
 /turf/open/floor/plating,
 /area/maintenance/external/port/bow)
 "enN" = (
-/obj/effect/spawner/randomarcade{
+/obj/machinery/computer/arcade/battle{
 	dir = 1
 	},
-/obj/structure/fluff/broken_flooring,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -25521,6 +25520,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"eOD" = (
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/plating/rust,
+/area/commons/vacant_room)
 "eOE" = (
 /obj/item/toy/plush/slimeplushie,
 /obj/effect/landmark/event_spawn,
@@ -33810,7 +33813,7 @@
 /turf/open/floor/plating,
 /area/maintenance/external/port/bow)
 "gKN" = (
-/obj/effect/spawner/randomarcade,
+/obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/iron,
 /area/commons/vacant_room)
 "gKP" = (
@@ -40239,7 +40242,7 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "ijv" = (
-/obj/effect/spawner/randomarcade,
+/obj/machinery/computer/slot_machine,
 /turf/open/floor/plating,
 /area/commons/vacant_room)
 "ijJ" = (
@@ -50584,9 +50587,7 @@
 /area/medical/medbay/zone2)
 "kxr" = (
 /obj/structure/cable,
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
+/obj/structure/chair/stool/bar,
 /turf/open/floor/plating,
 /area/commons/vacant_room)
 "kxv" = (
@@ -56669,6 +56670,10 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
+"lPc" = (
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/iron,
+/area/commons/vacant_room)
 "lPo" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/yellow,
@@ -60236,7 +60241,7 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "mCL" = (
-/obj/effect/spawner/randomarcade,
+/obj/effect/spawner/randomsnackvend,
 /obj/structure/fluff/broken_flooring{
 	dir = 4;
 	icon_state = "pile"
@@ -70432,11 +70437,8 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "oOe" = (
-/obj/effect/spawner/randomarcade{
+/obj/machinery/computer/arcade/orion_trail{
 	dir = 1
-	},
-/obj/structure/fluff/broken_flooring{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/commons/vacant_room)
@@ -70447,6 +70449,10 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/commons/toilet/restrooms)
+"oOl" = (
+/obj/item/storage/secure/safe/caps_spare,
+/turf/closed/wall/r_wall,
+/area/command/meeting_room/council)
 "oOm" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm/directional/west,
@@ -74115,6 +74121,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"pCS" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating/rust,
+/area/commons/vacant_room)
 "pCT" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/small/directional/north,
@@ -85747,7 +85757,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "soZ" = (
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/plating/rust,
 /area/commons/vacant_room)
 "spj" = (
@@ -85947,7 +85957,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "srK" = (
-/obj/effect/spawner/randomarcade,
+/obj/effect/spawner/randomcolavend,
 /obj/structure/fluff/broken_flooring{
 	dir = 8;
 	icon_state = "pile"
@@ -91221,6 +91231,10 @@
 "tFp" = (
 /turf/closed/wall,
 /area/service/chapel/office)
+"tFz" = (
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/iron,
+/area/commons/vacant_room)
 "tFO" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -93149,9 +93163,6 @@
 /obj/structure/fluff/broken_flooring{
 	dir = 4;
 	icon_state = "pile"
-	},
-/obj/structure/chair/stool/bar{
-	dir = 1
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -123467,7 +123478,7 @@ brp
 brp
 brp
 qAb
-soZ
+aQT
 lRn
 qeU
 sJn
@@ -123724,7 +123735,7 @@ brp
 brp
 brp
 qAb
-soZ
+eOD
 ugh
 dPO
 jQX
@@ -123981,7 +123992,7 @@ ori
 lcu
 ori
 qAb
-soZ
+pCS
 kGA
 jQk
 sJn
@@ -126898,7 +126909,7 @@ fVo
 dMR
 cFp
 vDN
-gKN
+tFz
 osK
 uAZ
 amF
@@ -127669,7 +127680,7 @@ bSK
 dMR
 cFp
 vDN
-gKN
+lPc
 qyR
 jAe
 aMj
@@ -147998,7 +148009,7 @@ aaw
 pnT
 wvU
 urp
-brA
+oOl
 evC
 eKT
 xvk

--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -13204,7 +13204,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/computer/arcade/amputation/festive,
+/obj/machinery/computer/arcade/orion_trail,
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -13264,7 +13264,7 @@
 /area/hallway/secondary/entry)
 "cil" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/computer/arcade/amputation,
+/obj/machinery/computer/arcade/battle,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "cio" = (


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Two arcade machines in arrivals/evac were mediborg's amputation adventure (and the festive version). They have been replaced with orion trail and battle arcade machines.

Also noticed that Cap's spare ID safe was underneath a photocopier? That has been moved into bridge.

## Why It's Good For The Game
Regular players finding the AA (this is a bad thing)
![image](https://user-images.githubusercontent.com/71316563/124744477-b55d5780-df16-11eb-9253-b9a135954439.png)

Red outline is where the safe used to be.
![image](https://user-images.githubusercontent.com/71316563/124747783-3bc76880-df1a-11eb-99aa-fa9a6a3dfc56.png)


## Changelog
:cl:
del: Arcade machines
fix: Fixed the spare ID safe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
