### PR TITLE
Atmos fixes 2

### DIFF
--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -7779,9 +7779,6 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "bfE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -8997,7 +8994,7 @@
 	dir = 9
 	},
 /obj/structure/reflector/box,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "bov" = (
 /obj/machinery/door/firedoor,
@@ -10994,9 +10991,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bMY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -11109,7 +11103,7 @@
 /area/ai_monitored/command/storage/eva)
 "bOg" = (
 /obj/structure/cable,
-/obj/machinery/light/floor,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bOt" = (
@@ -11222,7 +11216,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "bQc" = (
 /obj/item/storage/toolbox/emergency,
@@ -12987,7 +12981,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "chz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -17023,8 +17017,8 @@
 /area/science/mixing)
 "cLc" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -17214,6 +17208,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"cMI" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cMK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18330,7 +18330,7 @@
 	dir = 8
 	},
 /obj/structure/reflector/box,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "dcG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -20601,17 +20601,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = 5
-	},
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = -5
-	},
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
 /obj/effect/turf_decal/siding/yellow{
-	dir = 9
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
@@ -21043,6 +21034,9 @@
 	c_tag = "Atmospheric - Monitering";
 	dir = 8;
 	name = "Camera"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -22618,12 +22612,10 @@
 /area/commons/dorms)
 "egp" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow{
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -22649,9 +22641,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "egT" = (
@@ -22900,12 +22890,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
-"ejZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "ekm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -22936,11 +22920,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ela" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 1
-	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "elf" = (
@@ -25996,8 +25978,7 @@
 /turf/open/floor/plating,
 /area/solars/aux/port)
 "eUy" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/engineering/main)
 "eUS" = (
 /obj/structure/disposalpipe/segment{
@@ -26766,13 +26747,13 @@
 /area/medical/medbay/central)
 "fcm" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -31288,7 +31269,6 @@
 /turf/open/floor/carpet/purple,
 /area/service/bar)
 "ghK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
 /obj/machinery/meter/atmos/distro_loop,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -32131,7 +32111,7 @@
 	dir = 5
 	},
 /obj/structure/reflector/box,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "grt" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
@@ -34553,15 +34533,10 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "gXF" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 1
-	},
 /obj/machinery/airalarm/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/chair/office,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
@@ -34570,6 +34545,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Fuel Pipe to Incinerator"
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "gXJ" = (
@@ -35238,8 +35216,12 @@
 /turf/open/floor/wood,
 /area/command/bridge)
 "hfU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 4
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -35755,13 +35737,11 @@
 /turf/open/floor/iron/grimy,
 /area/security/office)
 "hnc" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filter"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "hnd" = (
 /obj/structure/table/glass,
@@ -36437,7 +36417,7 @@
 	dir = 1;
 	network = list("ss13","engine")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/engineering/main)
 "huc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -36837,13 +36817,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing)
-"hxG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/yellow,
-/turf/open/floor/iron,
-/area/engineering/main)
 "hxL" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/disposalpipe/segment{
@@ -37791,7 +37764,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "hKL" = (
 /turf/closed/wall/r_wall,
@@ -37868,6 +37841,10 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Distro to Waste"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hLu" = (
@@ -37895,6 +37872,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"hLD" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hLH" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/cable,
@@ -40512,7 +40496,7 @@
 /turf/open/floor/wood,
 /area/service/library)
 "iol" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -40989,7 +40973,7 @@
 	dir = 4
 	},
 /obj/structure/reflector/box,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "ith" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -41110,11 +41094,9 @@
 /area/engineering/atmos)
 "iuQ" = (
 /obj/structure/sign/warning/fire,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 1
-	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "ivi" = (
@@ -41196,12 +41178,10 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "iwj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
@@ -43002,10 +42982,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iSR" = (
@@ -44580,12 +44557,10 @@
 /area/engineering/atmos)
 "jkW" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -46558,7 +46533,7 @@
 /area/maintenance/starboard/aft)
 "jHU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/engineering/main)
 "jIj" = (
 /obj/machinery/hydroponics/constructable,
@@ -48700,7 +48675,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/atmos{
 	name = "Turbine Generator Access";
-	req_one_access_txt = "24;10"
+	req_one_access_txt = "24"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -48953,9 +48928,6 @@
 "kgW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -49487,11 +49459,11 @@
 "kmG" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 8
-	},
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -49669,9 +49641,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
@@ -49707,11 +49676,9 @@
 /area/science/research)
 "koO" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "koT" = (
@@ -52794,8 +52761,8 @@
 	},
 /area/service/abandoned_gambling_den)
 "kYx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kYA" = (
@@ -53596,7 +53563,7 @@
 "lim" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 10
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -54346,6 +54313,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lrs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "lry" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -54468,7 +54441,7 @@
 "lsy" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Air Mix to External Air Ports"
+	name = "Air Mix to Distro"
 	},
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/yellow{
@@ -55913,13 +55886,11 @@
 /area/medical/virology)
 "lJs" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -56344,12 +56315,10 @@
 /area/science/misc_lab)
 "lOe" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/green{
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -58799,9 +58768,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "mmV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring";
@@ -60921,9 +60887,6 @@
 /area/command/bridge)
 "mNX" = (
 /obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mOc" = (
@@ -61205,6 +61168,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"mRj" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage_shared)
 "mRm" = (
 /obj/effect/spawner/randomarcade,
 /obj/machinery/light/directional/north,
@@ -61527,9 +61496,6 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "mUN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -63561,7 +63527,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "nrZ" = (
 /obj/machinery/door/firedoor,
@@ -67467,10 +67433,6 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "oll" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Distro to Waste"
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 1
@@ -67527,6 +67489,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"olY" = (
+/turf/open/floor/plating,
+/area/engineering/storage_shared)
 "oma" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
@@ -69831,7 +69796,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "oLA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69849,7 +69814,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/engineering/main)
 "oLK" = (
 /obj/effect/turf_decal/siding/blue{
@@ -69922,11 +69887,8 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "oMx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/yellow,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "oMz" = (
 /obj/structure/table/wood,
@@ -69981,6 +69943,15 @@
 "oNH" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/table/reinforced,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 5
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -5
+	},
+/obj/item/geiger_counter,
+/obj/item/geiger_counter,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
 "oNI" = (
@@ -70617,6 +70588,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"oUA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "oUU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -71005,7 +70986,7 @@
 /area/maintenance/external/port)
 "oZM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/engineering/main)
 "oZO" = (
 /obj/structure/cable,
@@ -71894,7 +71875,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/yellow,
 /obj/structure/reflector/single,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "pkE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -72005,7 +71986,7 @@
 "pmg" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/structure/reflector/single,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "pmq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -72717,6 +72698,9 @@
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pst" = (
@@ -74415,6 +74399,13 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"pMT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pMV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74769,14 +74760,11 @@
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
 "pRf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "pRp" = (
 /obj/item/radio/intercom/directional/west,
@@ -74854,6 +74842,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"pSs" = (
+/obj/machinery/door/airlock/external{
+	name = "Departure Lounge Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/storage_shared)
 "pSB" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/siding/purple{
@@ -75604,15 +75601,6 @@
 	},
 /area/maintenance/starboard/aft)
 "qcs" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
 "qcF" = (
@@ -75680,7 +75668,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "qdz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
@@ -76083,10 +76071,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "qgY" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qhd" = (
@@ -76520,6 +76507,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qmS" = (
@@ -78133,6 +78123,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qEb" = (
@@ -78516,6 +78509,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -79363,6 +79359,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"qUw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "qUG" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/item/storage/backpack/satchel/explorer,
@@ -82503,7 +82505,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "rGO" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -82990,7 +82992,7 @@
 	dir = 8
 	},
 /obj/structure/reflector/box,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "rMB" = (
 /turf/open/floor/iron,
@@ -83501,15 +83503,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 10
-	},
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /obj/item/clothing/head/radiation,
 /obj/item/pipe_dispenser,
+/obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
 "rTf" = (
@@ -87509,7 +87509,7 @@
 	dir = 4
 	},
 /obj/structure/reflector/box,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "sPP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -88242,9 +88242,17 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "sZQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
-/turf/open/floor/iron,
-/area/engineering/main)
+/obj/effect/turf_decal/siding/yellow{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/sign/warning/pods{
+	pixel_x = -30
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage_shared)
 "sZU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -88448,7 +88456,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/engineering/main)
 "tcm" = (
 /obj/effect/turf_decal/siding/blue/corner{
@@ -88675,9 +88683,6 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "teY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -89465,7 +89470,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tqs" = (
@@ -89617,9 +89624,6 @@
 	},
 /area/maintenance/starboard/aft)
 "tsv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/structure/sign/warning/fire{
 	pixel_x = -32
 	},
@@ -89630,6 +89634,9 @@
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -89796,11 +89803,11 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "tvA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -91058,9 +91065,6 @@
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "tKz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
@@ -91071,6 +91075,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tKC" = (
@@ -91284,13 +91289,10 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "tMu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/engineering/main)
 "tMx" = (
 /obj/machinery/light/directional/east,
@@ -93305,6 +93307,10 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"uiK" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "uiP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -97889,9 +97895,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "vhX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
@@ -97901,6 +97904,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -99039,11 +99045,8 @@
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vwR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/effect/turf_decal/siding/yellow/corner,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/engineering/main)
 "vwU" = (
 /obj/effect/decal/cleanable/blood,
@@ -100681,7 +100684,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "vQT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
@@ -100689,6 +100691,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vQU" = (
@@ -100980,6 +100983,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/upper)
+"vUF" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vUL" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "gatewayshutters";
@@ -101481,6 +101490,18 @@
 	},
 /turf/open/floor/eighties,
 /area/maintenance/starboard/aft)
+"wcU" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/sign/warning/pods{
+	pixel_x = -30
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage_shared)
 "wcY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown{
@@ -102276,7 +102297,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wnm" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "wnx" = (
@@ -103376,14 +103397,13 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "wBF" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
+/obj/docking_port/stationary/random{
+	dir = 8;
+	id = "pod_lavaland2";
+	name = "lavaland"
 	},
-/obj/machinery/light/directional/south{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/turf/open/space/basic,
+/area/space)
 "wBH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -103610,9 +103630,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "wDB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -104486,7 +104503,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/yellow,
 /obj/structure/reflector/double,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "wOP" = (
 /obj/machinery/light/directional/east,
@@ -107108,7 +107125,7 @@
 "xsV" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/structure/reflector/double,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "xsZ" = (
 /obj/machinery/firealarm/directional/east,
@@ -107853,15 +107870,16 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
 "xyM" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_y = 32
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
 	},
-/turf/closed/wall/r_wall,
-/area/engineering/main)
+/turf/open/space/basic,
+/area/space)
 "xyN" = (
 /obj/machinery/atmospherics/components/binary/pump/layer4,
 /turf/open/floor/plating,
@@ -110569,9 +110587,8 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "ydg" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Fuel Pipe to Incinerator"
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -110623,6 +110640,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"ydM" = (
+/obj/machinery/door/airlock/external{
+	name = "Departure Lounge Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/storage_shared)
 "ydN" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube,
@@ -136778,7 +136804,7 @@ cFp
 cFp
 cFp
 cFp
-cFp
+wBF
 cFp
 cFp
 cFp
@@ -137806,7 +137832,7 @@ cFp
 cFp
 cFp
 cFp
-cFp
+xyM
 cFp
 cFp
 cFp
@@ -138062,9 +138088,9 @@ cFp
 ccW
 aae
 aae
-ccX
-ccW
-aae
+akz
+pSs
+akz
 hoM
 hoM
 wDF
@@ -138319,10 +138345,10 @@ aae
 aae
 ccX
 ccX
-aae
-ccX
-aae
-xyM
+akz
+olY
+akz
+hoM
 fJp
 bEW
 oUe
@@ -138576,9 +138602,9 @@ aae
 aae
 ccW
 ccW
-aae
-ccW
-ccW
+akz
+olY
+akz
 fxU
 vKa
 ddr
@@ -138833,9 +138859,9 @@ akz
 akz
 akz
 akz
-ccW
-ccX
-aae
+akz
+ydM
+akz
 hoM
 ciI
 dvK
@@ -139090,9 +139116,9 @@ ovE
 gkT
 aBc
 akz
-akz
-akz
-akz
+sZQ
+mRj
+wcU
 hoM
 muQ
 dvK
@@ -139624,9 +139650,9 @@ xpn
 bhX
 xiM
 hKI
-fhh
-fhh
-fhh
+eUy
+eUy
+eUy
 xsV
 hoM
 cFp
@@ -139881,9 +139907,9 @@ xpn
 rSe
 xiM
 hKI
-fhh
-fhh
-fhh
+eUy
+eUy
+eUy
 xsV
 hoM
 cFp
@@ -140138,9 +140164,9 @@ xpn
 eiQ
 bzu
 hKI
-fhh
-fhh
-fhh
+eUy
+eUy
+eUy
 wOL
 hoM
 cFp
@@ -140396,7 +140422,7 @@ gDM
 hbu
 oLH
 oZM
-psB
+qUw
 eUy
 oMx
 hoM
@@ -140652,8 +140678,8 @@ xpn
 bhX
 wDF
 pRf
-ime
-ime
+eUy
+eUy
 vwR
 oLx
 hoM
@@ -140909,8 +140935,8 @@ iom
 vcq
 wDF
 hKI
-fhh
-fhh
+eUy
+eUy
 htS
 hoM
 hoM
@@ -141166,8 +141192,8 @@ xpn
 rSe
 wDF
 chy
-bNm
-bNm
+eUy
+eUy
 tMu
 nrX
 hoM
@@ -141424,9 +141450,9 @@ tpd
 myz
 tbJ
 jHU
-hkm
-ejZ
-hxG
+lrs
+eUy
+oMx
 hoM
 cFp
 aaa
@@ -141680,9 +141706,9 @@ xpn
 mmb
 bzu
 hKI
-fhh
-fhh
-fhh
+eUy
+eUy
+eUy
 pkv
 hoM
 cFp
@@ -141937,9 +141963,9 @@ xpn
 bhX
 dEM
 hKI
-fhh
-fhh
-fhh
+eUy
+eUy
+eUy
 pmg
 hoM
 cFp
@@ -142194,9 +142220,9 @@ xpn
 rSe
 xiM
 hKI
-fhh
-fhh
-fhh
+eUy
+eUy
+eUy
 pmg
 hoM
 cFp
@@ -142696,12 +142722,12 @@ nQj
 svs
 haq
 jGw
-sZQ
+ydm
 aug
 bSG
 fhh
 fhh
-sZQ
+ydm
 fhh
 heb
 xpn
@@ -142953,12 +142979,12 @@ nWA
 dvK
 fhh
 fhh
-sZQ
-sZQ
-sZQ
-sZQ
-sZQ
-sZQ
+ydm
+ydm
+ydm
+ydm
+ydm
+ydm
 fhh
 heb
 xpn
@@ -145789,7 +145815,7 @@ tJU
 mpK
 mpK
 mpK
-wnm
+uiK
 qdz
 uVL
 skw
@@ -146806,7 +146832,7 @@ qVm
 syD
 ehv
 ehv
-ehv
+cMI
 etW
 uwZ
 heu
@@ -147063,7 +147089,7 @@ fIs
 wlm
 kAK
 bOg
-kAK
+pMT
 kDX
 vwz
 fHK
@@ -147309,7 +147335,7 @@ gJH
 ila
 gJH
 tvu
-tvu
+cLc
 bMY
 fZv
 gJH
@@ -147318,9 +147344,9 @@ msa
 lkC
 fXU
 xMA
+hLD
 ehv
-ehv
-ehv
+jnz
 etW
 woi
 msa
@@ -147566,7 +147592,7 @@ aaU
 mwl
 gJH
 eCA
-jgK
+hfU
 mUN
 gle
 gJH
@@ -147576,9 +147602,9 @@ ehv
 xBL
 ehv
 qgY
-qgY
+vUF
 mNX
-qVm
+etW
 hqe
 mMz
 fSc
@@ -147831,10 +147857,10 @@ hvk
 rNT
 lvN
 kYx
-lvN
-hfU
-hfU
-hnc
+ehv
+jnz
+ehv
+iKY
 qVm
 woi
 eti
@@ -148097,7 +148123,7 @@ woi
 msa
 ohF
 vWY
-ksk
+tcM
 hMN
 cFp
 syb
@@ -148337,7 +148363,7 @@ gJH
 met
 gJH
 tvu
-tvu
+cLc
 mmV
 fZv
 gJH
@@ -149108,9 +149134,9 @@ tiV
 suP
 pDP
 pDP
-tvu
+hnc
 lim
-cLc
+tvu
 tvu
 swA
 dWu
@@ -150153,7 +150179,7 @@ aNT
 ehv
 ehv
 vWY
-wGt
+tcM
 lFy
 cFp
 syb
@@ -150662,7 +150688,7 @@ fGE
 bgQ
 nDY
 vmG
-wBF
+rcT
 cSn
 hHK
 hMO
@@ -150920,7 +150946,7 @@ egp
 koO
 lOe
 ela
-egp
+oUA
 koO
 lOe
 ela


### PR DESCRIPTION


## About The Pull Request

**Fixes:**

Waste pipes connecting to atmos ports.
Turbine mix connecting to turbine disposal.
Mix to waste and Distro to waste pipes connecting.
Hidden SM mix pipes.
Emitter room flooring.
Hidden pipes along the right side of atmos.
Paramed turbine access.
Turbine waste and distro not working at all.

**Additions:**

Engineering escape pod.

**To do list:**

Make SM a little larger (just change the flooring for placebo effect).
Add better ways for engies to access space.
Re do secure tech storage.
Figure out what causes this at roundstart.
![image](https://user-images.githubusercontent.com/71316563/125445211-4137ac3f-a5d5-4c0c-b492-e15bde6759a1.png)

 



## Why It's Good For The Game

Fixes mean more efficiency and improved clarity.

Escape pod means less trekking during evac.

## Changelog
:cl:
add: Engineering escape pod!
fix: Smart pipes fucking up atmos
/:cl:
