### PR TITLE
Reworks EosStation's Medbay

### DIFF
--- a/_maps/map_files/Eosstation/EosStation.dmm
+++ b/_maps/map_files/Eosstation/EosStation.dmm
@@ -357,6 +357,15 @@
 "acN" = (
 /turf/open/floor/iron,
 /area/security/prison)
+"acP" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "acT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -808,10 +817,16 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
 /area/medical/morgue)
 "ahD" = (
 /obj/structure/lattice,
@@ -1033,12 +1048,21 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "akl" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/white/corner{
+	dir = 4
+	},
+/area/medical/break_room)
 "ako" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
@@ -1664,15 +1688,11 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/blue/corner,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aoB" = (
@@ -2355,6 +2375,15 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/service/lawoffice)
+"ata" = (
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "atc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
@@ -2382,14 +2411,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/command/nuke_storage)
-"atl" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "surgerya";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/surgery)
 "atu" = (
 /obj/structure/table/reinforced,
 /obj/item/instrument/musicalmoth,
@@ -2469,23 +2490,11 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "aum" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera{
-	c_tag = "Medbay - Surgery 3";
-	dir = 4;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_c)
+/area/medical/storage)
 "aun" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil{
@@ -3427,12 +3436,9 @@
 /area/security/execution/education)
 "aCh" = (
 /obj/effect/turf_decal/siding/blue{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/morgue)
 "aCk" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -4192,6 +4198,16 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/carpet/lone,
 /area/service/chapel)
+"aIT" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/cmo)
 "aIU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
 	dir = 1
@@ -5489,10 +5505,15 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aVj" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 8
+	},
+/area/medical/surgery)
 "aVm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
@@ -5728,10 +5749,10 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "aWD" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "aWN" = (
@@ -7683,11 +7704,12 @@
 /area/maintenance/external/port)
 "beH" = (
 /obj/structure/chair/office/light,
+/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -8605,6 +8627,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"bkW" = (
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "blj" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/disposal/bin,
@@ -8953,11 +8981,13 @@
 /turf/open/floor/carpet/red,
 /area/hallway/primary/starboard)
 "bnp" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/warning{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "bnr" = (
@@ -9021,23 +9051,9 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "bob" = (
-/obj/item/pet_carrier,
-/obj/item/clothing/neck/petcollar,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay - CMO Office";
-	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "bog" = (
@@ -9076,12 +9092,39 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "boW" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 6
+/obj/structure/table/glass,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_c)
+/obj/item/storage/firstaid/o2{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/o2{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/storage/firstaid{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/white/textured,
+/area/medical/storage)
 "bpb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9337,6 +9380,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
@@ -9871,6 +9917,14 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Space Suit 2 - Medbay ";
+	dir = 6;
+	name = "Camera"
+	},
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "bwE" = (
@@ -10080,19 +10134,18 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "bxQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue/corner,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -10780,6 +10833,12 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/wood,
 /area/command/bridge)
+"bHY" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/cmo)
 "bHZ" = (
 /obj/item/toy/foamblade,
 /obj/structure/lattice,
@@ -11116,9 +11175,6 @@
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "bMA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -11126,6 +11182,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "bMI" = (
@@ -11753,6 +11813,13 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
+"bVT" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "bWj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red{
@@ -11850,6 +11917,18 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
+"bXL" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay - Examination S";
+	dir = 10;
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "bXM" = (
 /obj/structure/sink{
 	dir = 4;
@@ -12534,10 +12613,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/large,
 /area/hallway/primary/starboard)
-"cdw" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/medical/surgery/room_b)
 "cdx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -12596,6 +12671,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"cdI" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 8
+	},
+/area/medical/surgery)
 "cdM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -14956,6 +15041,29 @@
 /obj/effect/turf_decal/stripes/red/box,
 /turf/open/floor/engine,
 /area/hallway/secondary/construction/engineering)
+"csr" = (
+/obj/structure/closet/secure_closet/chief_medical,
+/obj/item/cartridge/medical{
+	pixel_x = -3
+	},
+/obj/item/cartridge/chemistry{
+	pixel_y = 6
+	},
+/obj/item/cartridge/medical{
+	pixel_x = -3
+	},
+/obj/item/assembly/igniter,
+/obj/item/radio,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/command/heads_quarters/cmo)
 "csC" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -16351,9 +16459,9 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "cEl" = (
-/obj/machinery/smartfridge/organ,
-/turf/closed/wall,
-/area/medical/surgery/room_b)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/storage)
 "cEr" = (
 /obj/item/wallframe/light_fixture{
 	dir = 1;
@@ -16888,6 +16996,18 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
+"cJt" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/cmo)
 "cJv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17600,20 +17720,14 @@
 /turf/open/floor/bluespace,
 /area/hallway/secondary/construction)
 "cPQ" = (
-/obj/machinery/door/airlock{
-	name = "Medbay Auxiliary Storage";
-	req_access_txt = "5"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cmoshutter";
+	name = "CMO Office Shutters"
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/white,
-/area/maintenance/starboard/aft)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/heads_quarters/cmo)
 "cPS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -17837,20 +17951,25 @@
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cTB" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
-	},
-/obj/structure/table,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/computer/crew{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
+"cTF" = (
+/obj/structure/sign/poster/random,
+/turf/closed/wall,
+/area/medical/patients_rooms)
 "cTG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18288,8 +18407,10 @@
 /area/hallway/primary/fore)
 "cZm" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cZr" = (
 /turf/closed/mineral/random/low_chance,
@@ -18507,6 +18628,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"dcJ" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 10
+	},
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "ddc" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/remains/human,
@@ -18687,16 +18818,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -18909,7 +19034,6 @@
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/blue/corner,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/white,
@@ -19024,17 +19148,13 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "djE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 5
 	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "djJ" = (
@@ -19145,9 +19265,16 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "dlm" = (
-/obj/structure/sign/poster/random,
-/turf/closed/wall,
-/area/maintenance/external/port)
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Morgue Medbay"
+	},
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/medical/morgue)
 "dlp" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/machinery/camera{
@@ -20171,22 +20298,10 @@
 /area/medical/chemistry)
 "dzl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -20674,15 +20789,16 @@
 /area/maintenance/starboard/aft)
 "dFg" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron/white/textured,
+/area/medical/patients_rooms)
 "dFh" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -20697,15 +20813,13 @@
 /area/hallway/primary/aft)
 "dFH" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
+/obj/machinery/vending/drugs,
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
-/area/medical/pharmacy)
+/area/medical/storage)
 "dFJ" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -21541,15 +21655,17 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dPq" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 6
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/structure/table,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron/white/textured,
+/area/medical/patients_rooms)
 "dPA" = (
 /turf/open/floor/iron/stairs/left{
 	dir = 1
@@ -21642,16 +21758,18 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dQp" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
+/obj/machinery/door/airlock/medical/glass{
+	name = "Pharmacy";
+	req_access_txt = "5; 69"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/pharmacy)
 "dQr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/red/corner{
@@ -22414,12 +22532,18 @@
 /turf/open/floor/iron/dark/textured,
 /area/command/gateway)
 "dZs" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/structure/chair/office/light{
+	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
 "dZv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -22497,20 +22621,19 @@
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard/aft)
 "eaE" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
+/obj/machinery/camera{
+	c_tag = "Medbay - CMO Office";
+	dir = 6;
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -22646,8 +22769,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ecE" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/siding/blue,
+/obj/effect/turf_decal/siding/blue/corner,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ecR" = (
@@ -22723,16 +22846,10 @@
 /turf/open/floor/mineral/silver,
 /area/hallway/secondary/construction/engineering)
 "edD" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 38
-	},
 /obj/effect/turf_decal/siding/blue{
-	dir = 4
+	dir = 5
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/morgue)
 "edX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -22846,24 +22963,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
-"efN" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical{
-	name = "Surgery Access";
-	req_access_txt = "45"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_c)
 "efW" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 1;
@@ -22974,6 +23073,11 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
+"eht" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/cmo)
 "ehv" = (
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -23258,19 +23362,27 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "elk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
+"elt" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
+/obj/effect/landmark/start/medical_doctor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "elv" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -23279,22 +23391,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"elx" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "ely" = (
 /obj/structure/mirror/directional/north{
 	pixel_y = 36
@@ -23480,14 +23576,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/external/port/bow)
-"enN" = (
-/obj/machinery/computer/arcade/battle{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard/aft)
 "enT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -23699,8 +23787,15 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "eqy" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/corner,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "eqD" = (
 /obj/effect/turf_decal/siding/purple{
@@ -24170,28 +24265,14 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "exc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/blue{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/blue,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Factory Front Desk";
-	req_access_txt = "5"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "exg" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating/rust,
@@ -24838,19 +24919,19 @@
 /area/service/chapel/office)
 "eFd" = (
 /obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Morgue";
 	dir = 4;
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/smooth_edge{
+	dir = 8
+	},
 /area/medical/morgue)
 "eFf" = (
 /obj/structure/cable,
@@ -25683,13 +25764,14 @@
 /turf/open/floor/holofloor/chapel,
 /area/service/chapel)
 "eOu" = (
-/obj/effect/turf_decal/siding/blue{
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white,
 /area/medical/morgue)
 "eOC" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
@@ -25873,14 +25955,8 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "ePY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
 /obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "eQb" = (
@@ -26339,11 +26415,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "eVy" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/smooth_corner{
+	dir = 8
+	},
 /area/medical/morgue)
 "eVA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -26393,6 +26470,19 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/upper)
+"eVM" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sign/departments/examroom{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "eVP" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -26772,6 +26862,17 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/port)
+"eZj" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white/textured,
+/area/medical/patients_rooms)
 "eZl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -27010,18 +27111,18 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "fbZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Surgery Room";
+	req_access_txt = "45"
+	},
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "fcb" = (
 /obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/siding/purple{
@@ -27039,9 +27140,6 @@
 /obj/structure/closet/bombcloset,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"fce" = (
-/turf/closed/wall,
-/area/medical/medbay/central)
 "fcm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
@@ -27096,18 +27194,11 @@
 /area/ai_monitored/turret_protected/ai)
 "fdF" = (
 /obj/machinery/light/directional/south,
-/obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/siding/blue,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
@@ -27155,6 +27246,20 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"feE" = (
+/obj/effect/turf_decal/siding/blue,
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/bag/bio,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "feF" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -27362,8 +27467,7 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "fgK" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/medical/medbay/central)
 "fha" = (
 /obj/structure/lattice/catwalk,
@@ -27419,6 +27523,17 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/maintenance/starboard/aft)
+"fhG" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron{
+	base_icon_state = "freezerfloor";
+	icon_state = "freezerfloor"
+	},
+/area/medical/treatment_center)
 "fhM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -27632,15 +27747,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -27784,14 +27890,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "fmO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -27885,16 +27991,10 @@
 /turf/open/space,
 /area/space/nearstation)
 "fol" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -28277,7 +28377,7 @@
 /area/security/prison/safe)
 "fsc" = (
 /turf/closed/wall,
-/area/medical/surgery)
+/area/medical/break_room)
 "fsf" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown,
@@ -28383,13 +28483,6 @@
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "ftp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue/corner,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -28704,25 +28797,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/upper)
 "fxy" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/pushbroom,
-/obj/item/screwdriver{
-	pixel_y = 6
-	},
-/obj/item/clothing/gloves/color/latex{
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
+/obj/machinery/light_switch/directional/north,
+/obj/structure/bodycontainer/morgue{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/smooth_corner{
+	dir = 8
+	},
 /area/medical/morgue)
 "fxz" = (
 /obj/effect/turf_decal/tile/purple,
@@ -28858,27 +28942,15 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "fyY" = (
-/obj/structure/closet/secure_closet/chief_medical,
-/obj/item/radio/headset/heads/cmo,
-/obj/item/clothing/neck/cloak/cmo,
-/obj/item/radio/headset/heads/cmo,
-/obj/item/radio/headset/heads/cmo,
-/obj/item/cartridge/medical{
-	pixel_x = -3
-	},
-/obj/item/cartridge/chemistry{
-	pixel_y = 6
-	},
-/obj/item/cartridge/medical{
-	pixel_x = -3
-	},
-/obj/item/assembly/igniter,
-/obj/effect/turf_decal/siding/blue{
-	dir = 6
-	},
-/obj/item/radio,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
@@ -29049,24 +29121,18 @@
 /area/hallway/primary/central)
 "fAX" = (
 /obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
+/obj/item/clothing/neck/stethoscope,
+/obj/item/stamp/cmo,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/item/pen/fourcolor,
-/obj/effect/turf_decal/siding/blue{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "fBc" = (
@@ -29149,16 +29215,22 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "fBD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen/fourcolor,
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "fBT" = (
@@ -29465,6 +29537,18 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/service/bar)
+"fEQ" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue";
+	req_access_txt = "5;6;45"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/medical/morgue)
 "fET" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -29478,24 +29562,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/upper)
 "fEZ" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Pharmacy";
-	req_access_txt = "5; 69"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
+/turf/closed/wall/r_wall,
+/area/medical/storage)
 "fFf" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -29655,6 +29724,18 @@
 "fGN" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/rd)
+"fGV" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/cmo)
 "fGY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -29876,6 +29957,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"fKe" = (
+/obj/effect/turf_decal/siding/blue,
+/obj/machinery/door/window/southleft{
+	dir = 8;
+	name = "Medbay Delivery";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "fKf" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
@@ -30758,10 +30849,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "fVi" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/machinery/vending/drugs,
+/obj/machinery/door/airlock/medical{
+	name = "Break Room";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/storage)
 "fVl" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -30940,6 +31035,14 @@
 	},
 /turf/open/floor/carpet/red,
 /area/service/library)
+"fWq" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/warning,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "fWu" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -31326,16 +31429,8 @@
 /turf/open/floor/iron/stairs/right,
 /area/service/chapel)
 "gal" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gar" = (
@@ -31582,6 +31677,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard/aft)
+"gcQ" = (
+/turf/closed/wall/r_wall,
+/area/medical/patients_rooms)
 "gcV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -31645,6 +31743,14 @@
 "gdM" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
+"gdV" = (
+/obj/effect/spawner/randomsnackvend,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "pile"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "gdW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -31847,6 +31953,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/rec)
+"gig" = (
+/obj/structure/cable,
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "pile"
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard/aft)
 "gil" = (
 /obj/machinery/light_switch/directional/east{
 	pixel_x = 38
@@ -32032,8 +32148,16 @@
 /area/security/prison/mess)
 "gls" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/chair/stool/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/break_room)
 "glx" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -32117,18 +32241,12 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "gml" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/machinery/camera{
-	c_tag = "Medbay - Main Hall 4";
-	dir = 1;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/storage)
 "gmp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -32261,9 +32379,15 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
 /area/medical/morgue)
 "gnQ" = (
 /obj/structure/cable,
@@ -32956,11 +33080,12 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "gvq" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "gvt" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet/royalblue,
@@ -33008,16 +33133,39 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "gwd" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
-	},
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/computer/operating{
+/obj/structure/table/glass,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_c)
+/obj/item/storage/firstaid/brute{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/brute{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/brute{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/storage/firstaid{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/white/textured,
+/area/medical/storage)
 "gwi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
@@ -33187,6 +33335,23 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"gyO" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/medical/treatment_center)
 "gyV" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/west,
@@ -33407,6 +33572,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"gCq" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/external/port)
 "gCu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -33682,6 +33854,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"gEX" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "gFg" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -33701,20 +33881,11 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "gFu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/blue/corner,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
-	},
+/obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "gFz" = (
@@ -33798,24 +33969,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/security/prison)
-"gHd" = (
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/siding/blue,
-/obj/structure/cable,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "gHh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -33954,9 +34107,10 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "gIM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "gIN" = (
@@ -34154,21 +34308,17 @@
 /turf/open/floor/circuit/green,
 /area/engineering/supermatter)
 "gKo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/blue,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Treatment Center";
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -34320,7 +34470,7 @@
 "gMg" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/closed/wall,
-/area/medical/surgery/room_c)
+/area/medical/storage)
 "gMi" = (
 /obj/structure/chair{
 	dir = 1
@@ -34336,6 +34486,18 @@
 /obj/effect/turf_decal/siding/green,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"gMt" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/item/bedsheet/medical,
+/turf/open/floor/iron/white/textured,
+/area/medical/patients_rooms)
 "gMD" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -34777,14 +34939,12 @@
 	},
 /area/maintenance/starboard/aft)
 "gSe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
-/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gSj" = (
@@ -34936,6 +35096,9 @@
 /obj/effect/landmark/start/paramedic,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -35229,9 +35392,19 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "gZg" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/medical/medbay/central)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Surgery Room";
+	req_access_txt = "45"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "gZj" = (
 /obj/structure/fluff/broken_flooring{
 	icon_state = "singular"
@@ -35293,13 +35466,13 @@
 /area/hallway/primary/port)
 "gZE" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/siding/blue{
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured_edge,
 /area/medical/treatment_center)
 "gZT" = (
 /turf/closed/wall/r_wall,
@@ -35319,9 +35492,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
-"haa" = (
-/turf/closed/wall/r_wall,
-/area/medical/storage)
 "hab" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/janitor,
@@ -35365,17 +35535,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "haD" = (
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "haF" = (
@@ -35676,14 +35840,14 @@
 /turf/open/floor/circuit/green,
 /area/science/xenobiology)
 "heC" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -35930,20 +36094,15 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/blue/corner,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
 /area/medical/morgue)
 "hhF" = (
 /obj/structure/fluff/broken_flooring{
@@ -36347,8 +36506,21 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"hmF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/external/port)
 "hmT" = (
-/turf/open/floor/iron/white,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
 /area/medical/morgue)
 "hmU" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -36631,17 +36803,17 @@
 /area/maintenance/starboard/aft)
 "hoW" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
+/obj/item/storage/box/beakers,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
-/area/medical/pharmacy)
+/area/medical/storage)
 "hoX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -36715,6 +36887,13 @@
 /obj/structure/window/reinforced,
 /turf/open/space,
 /area/space/nearstation)
+"hpo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "hpG" = (
 /obj/machinery/computer/med_data{
 	dir = 8
@@ -36849,15 +37028,11 @@
 /area/security/execution/education)
 "hrK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/vehicle/ridden/wheelchair{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -36963,8 +37138,15 @@
 /turf/open/floor/glass/reinforced,
 /area/hallway/secondary/construction/engineering)
 "hsz" = (
+/obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -37401,19 +37583,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"hwQ" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "hwW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37504,13 +37673,8 @@
 /area/maintenance/starboard/aft)
 "hyv" = (
 /obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/smooth_corner,
 /area/medical/morgue)
 "hyA" = (
 /obj/effect/landmark/start/chaplain,
@@ -37688,10 +37852,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "hAw" = (
@@ -37771,16 +37932,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/ai_upload)
-"hBB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/landmark/start/paramedic,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "hBI" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/red{
@@ -38060,6 +38211,21 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/upper)
+"hFj" = (
+/obj/structure/table/wood,
+/obj/item/toy/talking/codex_gigas,
+/obj/item/toy/plush/carpplushie,
+/obj/structure/fluff/broken_flooring{
+	dir = 8;
+	icon_state = "pile"
+	},
+/obj/item/coin/iron{
+	icon = 'icons/obj/tcgmisc.dmi';
+	icon_state = "coin_nanotrasen";
+	name = "arcade coin"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "hFr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 9
@@ -38319,9 +38485,16 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "hJd" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/r_wall,
-/area/medical/storage)
+/obj/machinery/door/airlock/medical{
+	name = "Freezer Storage";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "hJi" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
@@ -38611,16 +38784,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "hLS" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Morgue Medbay"
-	},
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "hLT" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/stripes/white/line{
@@ -38945,6 +39110,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"hPJ" = (
+/turf/closed/wall,
+/area/medical/patients_rooms)
 "hPL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -39256,37 +39424,29 @@
 /turf/closed/wall,
 /area/science/mixing)
 "hSn" = (
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/circular_saw,
-/obj/item/retractor,
-/obj/item/surgicaldrill{
-	pixel_y = 5
-	},
-/obj/item/book/manual/wiki/surgery,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/medical/storage)
 "hSs" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "hSw" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/computer/med_data{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/medical/patients_rooms)
 "hSz" = (
 /obj/structure/sign/poster/contraband/space_up,
 /turf/closed/wall/r_wall,
@@ -39313,11 +39473,20 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "hSE" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/table/glass,
+/obj/item/circular_saw,
+/obj/item/retractor,
+/obj/item/surgicaldrill{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 8
+	},
+/area/medical/surgery)
 "hSN" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -39793,22 +39962,15 @@
 /turf/open/floor/carpet/black,
 /area/service/theater)
 "hYg" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
+/obj/machinery/stasis,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/defibrillator_mount/directional/east,
+/turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
-/obj/machinery/stasis,
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "hYj" = (
 /mob/living/simple_animal/hostile/cockroach,
@@ -40100,14 +40262,9 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/satellite)
 "ibk" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/closet/firecloset/full,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
-/area/maintenance/external/port)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "ibp" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -40122,23 +40279,19 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "ibC" = (
-/obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/circular_saw,
-/obj/item/retractor,
-/obj/item/surgicaldrill{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/siding/blue{
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/item/book/manual/wiki/surgery,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/break_room)
 "ibE" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -40523,6 +40676,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "igo" = (
@@ -41286,17 +41442,22 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ioc" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/pushbroom,
+/obj/item/screwdriver{
+	pixel_y = 6
+	},
+/obj/item/clothing/gloves/color/latex{
+	pixel_y = 6
+	},
 /obj/effect/turf_decal/siding/blue{
-	dir = 10
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/morgue)
 "iod" = (
 /obj/machinery/libraryscanner,
@@ -41340,10 +41501,12 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "ioI" = (
-/obj/effect/landmark/start/paramedic,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 9
 	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "ioM" = (
@@ -41443,11 +41606,15 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "iqg" = (
-/obj/effect/turf_decal/siding/blue,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/blue/corner,
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "iqi" = (
@@ -41549,6 +41716,16 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
+"iqM" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 6
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "iqQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -41581,6 +41758,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"iro" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "iru" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -41599,6 +41784,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/upper)
+"iry" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 10
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "irH" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -41748,14 +41944,19 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ith" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes,
+/obj/item/gun/syringe,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/camera{
+	c_tag = "Medbay - Storage";
+	dir = 10;
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/siding/blue,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/storage)
 "itm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
@@ -41771,21 +41972,22 @@
 /turf/open/floor/engine,
 /area/maintenance/starboard/aft)
 "itx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
 /obj/machinery/door/airlock/medical/glass{
 	name = "Treatment Center";
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -42008,11 +42210,12 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/satellite)
 "ixj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/external/port)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "ixr" = (
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
@@ -42139,6 +42342,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/office)
+"iyJ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "iyK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -42910,38 +43121,22 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "iHt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/sign/poster/official/help_others{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
+/obj/machinery/iv_drip,
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "iHy" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/storage/belt/medical,
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = 6
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/iron/white/smooth_corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "iHI" = (
 /obj/machinery/light/directional/south,
@@ -43267,6 +43462,11 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"iMe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/closed/wall/rust,
+/area/maintenance/starboard/aft)
 "iMo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43312,11 +43512,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"iNi" = (
-/obj/structure/sign/warning/coldtemp,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/medbay/central)
 "iNl" = (
 /obj/structure/railing{
 	dir = 8;
@@ -44361,16 +44556,6 @@
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "iXB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "iXE" = (
@@ -44392,9 +44577,18 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "iXZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 4
+	},
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -44668,18 +44862,10 @@
 /turf/open/floor/plating/rust,
 /area/maintenance/fore/secondary)
 "jbS" = (
-/obj/effect/turf_decal/siding/blue/corner{
+/obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "jbT" = (
@@ -44963,20 +45149,9 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "jfv" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "jfF" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -45115,16 +45290,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
-"jha" = (
-/obj/structure/chair/office/light,
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
 "jhi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45336,12 +45501,16 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/fore)
 "jjy" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/structure/table/optable,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/medical/storage)
 "jjN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45597,6 +45766,18 @@
 /obj/item/tank/internals/oxygen,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
+"jng" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/cmo)
 "jnh" = (
 /obj/structure/bed/nest,
 /obj/machinery/light/small/directional/north,
@@ -47858,13 +48039,18 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "jMi" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "surgeryb";
-	name = "privacy shutters"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
 	},
-/turf/open/floor/plating,
-/area/medical/surgery/room_b)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "jMs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/official/work_for_a_future{
@@ -48507,13 +48693,36 @@
 /turf/open/floor/plating/beach/sand,
 /area/service/hydroponics/garden)
 "jSH" = (
-/obj/effect/turf_decal/siding/blue{
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/table/optable,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_c)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/storage/firstaid{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/white/textured,
+/area/medical/storage)
 "jSJ" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -48611,6 +48820,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/service/bar/atrium)
+"jTp" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "jTt" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/toy/cards/deck/cas,
@@ -48828,6 +49042,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"jVF" = (
+/obj/structure/bed/roller,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/medical/treatment_center)
 "jVM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -49119,6 +49343,11 @@
 	dir = 8
 	},
 /area/hallway/secondary/construction)
+"jYu" = (
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "jYB" = (
 /obj/structure/table/wood,
 /obj/item/assembly/timer,
@@ -49191,11 +49420,12 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "jZq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -49392,6 +49622,17 @@
 	dir = 4
 	},
 /area/command/gateway)
+"kbq" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron{
+	base_icon_state = "freezerfloor";
+	icon_state = "freezerfloor"
+	},
+/area/medical/treatment_center)
 "kbt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -49622,7 +49863,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/vehicle/ridden/wheelchair,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ker" = (
@@ -49843,23 +50083,16 @@
 /area/service/library)
 "kfZ" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/medical,
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/brute,
-/obj/structure/window/spawner/east,
-/obj/structure/window/spawner,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/brute,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/iron/white/textured_edge,
+/area/medical/surgery)
 "kgc" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable,
@@ -49892,14 +50125,13 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "kgA" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "kgO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -49939,9 +50171,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"khg" = (
-/turf/closed/wall/r_wall,
-/area/medical/surgery/room_b)
 "khs" = (
 /obj/structure/ore_box,
 /obj/machinery/camera{
@@ -50491,23 +50720,6 @@
 /obj/machinery/bluespace_vendor/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"knm" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "knq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50715,6 +50927,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "kpB" = (
@@ -51248,10 +51463,18 @@
 /area/service/chapel)
 "kvr" = (
 /obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/siding/blue{
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_edge{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
 /area/medical/morgue)
 "kvv" = (
 /turf/closed/wall/r_wall,
@@ -51373,11 +51596,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/bluespace,
 /area/medical/medbay/zone2)
-"kxr" = (
-/obj/structure/cable,
-/obj/structure/chair/stool/bar,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "kxv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51528,6 +51746,13 @@
 /obj/structure/sign/poster/random,
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
+"kzs" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "CMO Maintenance";
+	req_access_txt = "40"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "kzv" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 8
@@ -51736,24 +51961,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"kBQ" = (
-/obj/structure/table/wood,
-/obj/item/toy/talking/codex_gigas,
-/obj/item/coin/iron{
-	icon_state = "coin_bananium_heads";
-	name = "arcade coin"
-	},
-/obj/item/coin/iron{
-	icon_state = "coin_bananium_heads";
-	name = "arcade coin"
-	},
-/obj/item/toy/plush/carpplushie,
-/obj/structure/fluff/broken_flooring{
-	dir = 8;
-	icon_state = "pile"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "kCf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51934,30 +52141,17 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kDY" = (
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/toxin,
-/obj/machinery/door/window/eastleft{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/structure/sign/poster/official/help_others{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/siding/blue{
+/obj/structure/table/optable,
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge{
 	dir = 4
 	},
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/toxin,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "kEv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -52044,34 +52238,14 @@
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "kFG" = (
-/obj/structure/table/glass,
-/obj/item/stack/medical/gauze{
-	pixel_x = 8
-	},
-/obj/item/storage/box/rxglasses{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/chem_pack{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 6
-	},
+/obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/belt/medical,
-/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "kFH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -52087,27 +52261,31 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "kFL" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "surgeryc";
-	name = "privacy shutters"
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/medical/surgery/room_b)
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "kFM" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay Storage";
-	name = "Medbay Storage RC"
+/obj/machinery/camera{
+	c_tag = "Medbay - Surgery Room";
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
-/obj/machinery/rnd/production/protolathe/department/medical,
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
-	},
+/obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge,
+/area/medical/surgery)
 "kFS" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -52126,6 +52304,14 @@
 "kGg" = (
 /turf/open/floor/plating,
 /area/maintenance/external/port)
+"kGh" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/medical/treatment_center)
 "kGl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -52213,10 +52399,13 @@
 /area/maintenance/starboard/aft)
 "kHA" = (
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/siding/blue{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
 /area/medical/morgue)
 "kHD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52343,17 +52532,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"kIO" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/clothing/neck/stethoscope,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "kIX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -52778,11 +52956,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/east{
-	dir = 2;
-	pixel_x = 0;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
@@ -52792,6 +52965,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "kMJ" = (
@@ -52842,24 +53016,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"kNr" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "kNG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -53070,6 +53226,11 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/bluespace,
 /area/medical/medbay/zone2)
+"kQk" = (
+/obj/effect/turf_decal/siding/blue,
+/obj/machinery/power/apc/auto_name/south,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "kQo" = (
 /obj/structure/chair{
 	dir = 8
@@ -53111,14 +53272,11 @@
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "kQF" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
 "kQS" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/grimy,
@@ -53887,14 +54045,13 @@
 /turf/open/floor/plating,
 /area/solars/port)
 "kYL" = (
-/obj/machinery/light/directional/south{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "kYM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
@@ -54071,8 +54228,10 @@
 /turf/open/floor/eighties,
 /area/service/theater)
 "lbr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/warning{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -54268,7 +54427,7 @@
 /area/hallway/primary/central)
 "ldS" = (
 /turf/closed/wall,
-/area/medical/storage)
+/area/medical/surgery)
 "ldX" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/blood,
@@ -54555,6 +54714,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"lgd" = (
+/turf/closed/wall,
+/area/command/heads_quarters/cmo)
 "lgo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55615,6 +55777,17 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
+"ltJ" = (
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "ltM" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -55745,13 +55918,6 @@
 	icon_state = "singular"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard/aft)
-"luU" = (
-/obj/structure/cable,
-/obj/structure/fluff/broken_flooring,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -56123,28 +56289,15 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "lyQ" = (
-/obj/structure/table/glass,
-/obj/machinery/door/window/southleft{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
+/obj/structure/table/optable,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/item/storage/firstaid/medical,
-/obj/item/storage/firstaid/medical,
-/obj/item/storage/firstaid/medical,
-/obj/item/storage/firstaid/medical,
-/obj/item/storage/firstaid/medical,
-/obj/item/storage/firstaid/medical,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge,
+/area/medical/surgery)
 "lyR" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -57012,6 +57165,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"lJH" = (
+/obj/machinery/computer/arcade/battle{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/aft)
 "lJR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57085,21 +57246,19 @@
 /obj/machinery/light_switch/directional/east{
 	pixel_x = 38
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
+/obj/structure/table/glass,
+/obj/item/stack/medical/mesh,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/item/stack/medical/gauze{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "lKv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57285,10 +57444,9 @@
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard/aft)
 "lMp" = (
-/obj/machinery/smartfridge/organ,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
-/area/medical/surgery/room_c)
+/area/medical/storage)
 "lMv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -57364,22 +57522,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/carpet/royalblue,
 /area/command/meeting_room/council)
-"lNb" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "lNu" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/purple/corner{
@@ -57960,17 +58102,12 @@
 	},
 /area/maintenance/fore/secondary)
 "lSY" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/east,
-/obj/structure/fluff/broken_flooring{
-	dir = 8;
-	icon_state = "pile"
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
 	},
-/obj/structure/chair/stool/bar,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard/aft)
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "lTg" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -58372,13 +58509,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"lWu" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
+"lWp" = (
+/obj/machinery/smartfridge/organ,
+/turf/closed/wall,
 /area/medical/morgue)
 "lWA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58685,10 +58818,6 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "mar" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 1
 	},
@@ -58697,6 +58826,10 @@
 	name = "CMO Office Shutters";
 	pixel_x = 7;
 	req_access_txt = "40"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
@@ -59133,18 +59266,35 @@
 /area/engineering/atmos)
 "meG" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/circular_saw,
-/obj/item/retractor,
-/obj/item/surgicaldrill{
-	pixel_y = 5
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/item/book/manual/wiki/surgery,
-/obj/effect/turf_decal/siding/blue{
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_c)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/storage/firstaid{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/white/textured,
+/area/medical/storage)
 "meH" = (
 /obj/structure/table/glass,
 /obj/item/lipstick/purple,
@@ -59534,22 +59684,15 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "mkd" = (
-/obj/machinery/computer/med_data{
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/keycard_auth/directional/south,
+/obj/machinery/computer/crew{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
-	},
+/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "mkm" = (
@@ -60410,6 +60553,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"mtO" = (
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "mub" = (
 /obj/structure/table,
 /obj/item/storage/box/evidence,
@@ -60618,16 +60768,14 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "mwu" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/office/light{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_c)
+/area/medical/storage)
 "mwA" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/light/directional/south,
@@ -60645,9 +60793,14 @@
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
 "mwM" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/departments/examroom,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "mxe" = (
 /obj/structure/disposalpipe/segment,
@@ -60821,7 +60974,7 @@
 "mzl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall,
-/area/medical/surgery/room_c)
+/area/medical/storage)
 "mzo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -61124,13 +61277,17 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "mCL" = (
-/obj/effect/spawner/randomsnackvend,
-/obj/structure/fluff/broken_flooring{
-	dir = 4;
-	icon_state = "pile"
+/obj/structure/bed,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/bedsheet/medical,
+/turf/open/floor/iron/white/textured,
+/area/medical/patients_rooms)
 "mCM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -61147,10 +61304,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "mCZ" = (
-/obj/machinery/holopad,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_edge{
+	dir = 4
+	},
 /area/medical/morgue)
 "mDb" = (
 /obj/structure/cable,
@@ -61194,16 +61356,12 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mDH" = (
-/obj/effect/turf_decal/siding/blue/corner,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "mDO" = (
@@ -61770,6 +61928,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "mLc" = (
@@ -61786,14 +61948,6 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"mLi" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "mLn" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shower{
@@ -61930,6 +62084,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"mMG" = (
+/obj/structure/table/glass,
+/obj/item/storage/belt/medical,
+/obj/item/storage/box/masks,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron/white/smooth_edge{
+	dir = 4
+	},
+/area/medical/treatment_center)
 "mMN" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -62271,16 +62434,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mQW" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
 	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/medical/storage)
 "mRa" = (
 /obj/structure/cable,
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
@@ -62473,14 +62635,11 @@
 /turf/open/floor/plating,
 /area/solars/starboard)
 "mTq" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Morgue";
-	req_access_txt = "5"
+/obj/effect/turf_decal/siding/blue{
+	dir = 6
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/maintenance/external/port)
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "mTs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -62616,23 +62775,13 @@
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "mUx" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 1
+	},
 /area/medical/treatment_center)
 "mUz" = (
 /obj/machinery/atmospherics/components/binary/valve{
@@ -62795,16 +62944,13 @@
 /turf/open/floor/plating/beach/sand,
 /area/hallway/secondary/entry)
 "mVW" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
+/obj/machinery/light/directional/south,
+/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/siding/blue/corner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_c)
+/area/medical/storage)
 "mWd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63164,24 +63310,16 @@
 	pixel_x = 6
 	},
 /obj/item/stack/medical/mesh,
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
-	},
+/obj/machinery/airalarm/directional/north,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/storage/belt/medical,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/item/storage/firstaid,
-/obj/machinery/airalarm/directional/north,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/belt/medical,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured_edge,
 /area/medical/treatment_center)
 "naH" = (
 /obj/structure/table,
@@ -63370,9 +63508,14 @@
 	},
 /area/command/bridge)
 "ncN" = (
-/obj/machinery/smartfridge/organ,
-/turf/closed/wall,
-/area/medical/morgue)
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ndh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
 	dir = 4
@@ -63454,26 +63597,16 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "neq" = (
-/obj/machinery/space_heater,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
+/obj/effect/turf_decal/siding/blue,
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
 	},
-/turf/open/floor/plating/rust,
-/area/maintenance/starboard/aft)
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ner" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
-"neB" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "neE" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -64045,12 +64178,13 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "nkD" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/medical/storage)
 "nkT" = (
 /obj/effect/landmark/start/botanist,
 /obj/machinery/airalarm/directional/north,
@@ -64216,6 +64350,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "nmS" = (
@@ -64584,23 +64719,22 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "nqw" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/power/apc/auto_name/north,
-/obj/machinery/button/door/directional/west{
-	id = "surgerya";
-	name = "Privacy Shutters Control";
-	pixel_y = 26
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
+/area/medical/break_room)
 "nqC" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "MiniSat Chamber";
@@ -65408,23 +65542,18 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "nAG" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/medical{
-	name = "Surgery Access";
-	req_access_txt = "45"
+	name = "Break Room";
+	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/break_room)
 "nAP" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/siding/purple{
@@ -65580,6 +65709,14 @@
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron,
 /area/service/janitor)
+"nCI" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "nCS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
@@ -66093,14 +66230,22 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "nHG" = (
-/obj/effect/turf_decal/siding/blue{
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/structure/table/optable,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/medical/break_room)
 "nHJ" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -66225,24 +66370,19 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "nJD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light/directional/west,
-/obj/machinery/power/apc/auto_name/north,
-/obj/machinery/button/door/directional/west{
-	id = "surgeryb";
-	name = "Privacy Shutters Control";
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/wallframe/defib_mount,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/white/textured,
+/area/medical/storage)
 "nJH" = (
 /obj/effect/decal/cleanable/food/salt{
 	pixel_x = -2
@@ -66290,7 +66430,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/external/port)
@@ -66677,14 +66817,12 @@
 /turf/open/floor/wood,
 /area/service/library)
 "nPN" = (
-/obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
+	},
 /area/medical/morgue)
 "nPP" = (
 /obj/structure/cable,
@@ -66865,19 +67003,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nSK" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Examination";
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/medical_kiosk,
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nSL" = (
@@ -67490,12 +67618,12 @@
 /area/maintenance/starboard/aft)
 "nYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
 /area/medical/morgue)
 "nYU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -67618,6 +67746,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"oal" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "oax" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -67627,6 +67761,14 @@
 "oaN" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
+"oaQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "oaT" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/purple{
@@ -67948,31 +68090,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ofk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -68353,14 +68479,18 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "oiw" = (
-/obj/structure/sign/departments/medbay,
 /obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cmoshutter";
-	name = "CMO Office Shutters"
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
+	name = "Chief Medical Officer's Office";
+	req_access_txt = "40"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "oiy" = (
 /obj/structure/cable,
@@ -68742,11 +68872,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ola" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/departments/chemistry/pharmacy,
-/turf/open/floor/plating,
-/area/medical/pharmacy)
 "olg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68882,19 +69007,25 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "omB" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/computer/operating{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table,
+/obj/machinery/computer/med_data/laptop{
+	dir = 4;
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white/corner,
+/area/medical/break_room)
 "omG" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -68992,18 +69123,27 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"ons" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "onz" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"onB" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Freezer Storage";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "onP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -69128,6 +69268,10 @@
 "ooX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
+	},
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -69389,12 +69533,13 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "osE" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 6
+/obj/effect/turf_decal/siding/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/effect/turf_decal/tile/blue,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "osJ" = (
@@ -69853,6 +69998,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "oxn" = (
@@ -70017,16 +70163,21 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "ozr" = (
-/obj/effect/turf_decal/siding/blue{
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Medbay - Break  Room";
+	dir = 8;
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/office/light{
+/turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/break_room)
 "ozs" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -70034,15 +70185,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue{
 	dir = 8
-	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay Cold Room";
-	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
@@ -70056,6 +70199,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
+"ozO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/rack,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/open/floor/plating,
+/area/maintenance/external/port)
 "ozV" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/carpet/lone,
@@ -70208,18 +70364,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "oBx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/paramedic,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "oBC" = (
@@ -70406,6 +70555,22 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"oDM" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/syringe,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "oDW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -70693,6 +70858,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"oHD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "oHN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -70730,23 +70903,18 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "oHU" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera{
-	c_tag = "Medbay - Surgery 1";
-	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/medical/break_room)
 "oHX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70776,22 +70944,19 @@
 /area/hallway/primary/upper)
 "oIh" = (
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/o2,
-/obj/structure/window/spawner/north,
-/obj/structure/window/spawner/east,
-/obj/effect/turf_decal/siding/blue{
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/book/manual/wiki/surgery,
+/obj/item/circular_saw,
+/obj/item/retractor,
+/turf/open/floor/iron/white/textured_edge{
 	dir = 4
 	},
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/o2,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "oIu" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/purple,
@@ -71068,21 +71233,9 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "oLK" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Pharmacy Side Door";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
+/turf/closed/wall,
+/area/medical/storage)
 "oLO" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 10
@@ -71241,6 +71394,10 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/siding/blue,
+/obj/structure/sign/departments/examroom{
+	pixel_y = -32
+	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "oOa" = (
@@ -71270,11 +71427,9 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "oOe" = (
-/obj/machinery/computer/arcade/orion_trail{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "oOh" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
@@ -71292,12 +71447,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"oOu" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "oOv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71407,13 +71556,11 @@
 /turf/open/floor/engine,
 /area/hallway/secondary/command)
 "oPv" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
 "oPy" = (
 /turf/open/floor/mineral/titanium/white,
 /area/maintenance/starboard/aft)
@@ -71519,6 +71666,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/structure/sign/departments/examroom{
+	pixel_y = -32
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -71636,23 +71786,9 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "oSi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera{
-	c_tag = "Medbay - Surgery 2";
-	dir = 4;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/medical/storage)
 "oSL" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/siding/blue{
@@ -71849,6 +71985,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
+"oVm" = (
+/obj/structure/sign/poster/random,
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/cmo)
 "oVs" = (
 /obj/structure/chair/stool,
 /turf/open/floor/iron/white,
@@ -71960,10 +72100,13 @@
 /area/service/library)
 "oWI" = (
 /obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/siding/blue{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
 /area/medical/morgue)
 "oWK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
@@ -71987,10 +72130,7 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "oXl" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue/corner,
+/obj/effect/turf_decal/siding/blue,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -72541,18 +72681,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "pdD" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
-	},
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/turf/open/floor/iron/white/textured,
+/area/medical/storage)
 "pdK" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 8;
@@ -72679,12 +72811,11 @@
 /turf/open/floor/eighties,
 /area/service/theater)
 "peX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/rack,
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "pfr" = (
@@ -72852,14 +72983,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 6
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/medical/break_room)
 "phs" = (
 /turf/closed/wall,
 /area/science/research)
@@ -73145,12 +73282,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "pla" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/obj/machinery/light/directional/north,
+/obj/machinery/rnd/production/protolathe/department/medical,
+/turf/open/floor/iron/white/textured,
+/area/medical/storage)
 "plp" = (
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
@@ -73314,23 +73450,15 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "pnl" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical{
-	name = "Surgery Access";
-	req_access_txt = "45"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/medical/storage)
 "pnx" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/cable,
@@ -73455,17 +73583,14 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
 "poo" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 6
+	},
+/obj/machinery/vending/medical,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pop" = (
@@ -73596,9 +73721,8 @@
 /turf/open/floor/plating,
 /area/maintenance/external/aft)
 "ppo" = (
-/obj/effect/spawner/structure/window,
 /obj/structure/sign/warning/coldtemp,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/medical/medbay/central)
 "ppr" = (
 /obj/structure/cable,
@@ -73763,18 +73887,10 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "pqF" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/medical/storage)
 "pqG" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -73959,19 +74075,19 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pst" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
-/obj/machinery/camera{
-	c_tag = "Medbay - Maint Room";
-	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/runtime,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/command/heads_quarters/cmo)
 "psA" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/siding/red{
@@ -74266,25 +74382,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
-"pwl" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Break Room";
-	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/computer/med_data{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "pwp" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/central)
@@ -74310,22 +74407,15 @@
 /turf/open/floor/wood,
 /area/hallway/primary/port)
 "pwz" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
-/obj/structure/table/glass,
-/obj/item/storage/belt/medical,
-/obj/item/storage/box/masks,
-/obj/item/storage/firstaid,
-/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "pwC" = (
@@ -74418,20 +74508,10 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "pxf" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/medical/storage)
 "pxi" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating{
@@ -74682,14 +74762,14 @@
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/ai_upload)
 "pAj" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/structure/chair/stool,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
 "pAo" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -74819,18 +74899,10 @@
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pBS" = (
@@ -75171,12 +75243,16 @@
 /turf/open/floor/plating,
 /area/service/chapel/office)
 "pFC" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/vehicle/ridden/wheelchair{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/external/port)
+/obj/structure/window/spawner/east,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "pFD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75225,21 +75301,21 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "pFY" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/reagent_containers/syringe,
+/obj/machinery/camera{
+	c_tag = "Medbay - Examination N";
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/storage/belt/medical,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/machinery/newscaster/directional/north,
-/obj/item/clothing/neck/stethoscope,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured_edge,
 /area/medical/treatment_center)
 "pGa" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -75586,9 +75662,7 @@
 "pLh" = (
 /obj/effect/turf_decal/siding/blue,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/vehicle/ridden/wheelchair{
-	dir = 1
-	},
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pLi" = (
@@ -75897,6 +75971,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pOJ" = (
@@ -75965,10 +76040,16 @@
 /turf/closed/wall/r_wall,
 /area/command/bridge)
 "pPP" = (
-/obj/effect/turf_decal/siding/blue{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/obj/structure/chair,
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pPQ" = (
@@ -76000,9 +76081,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"pQp" = (
-/turf/closed/wall,
-/area/medical/surgery/room_c)
 "pQs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -76148,6 +76226,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pSs" = (
@@ -76416,17 +76495,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"pUY" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/vending/medical,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "pVl" = (
 /obj/structure/sign/poster/random,
 /turf/closed/wall,
@@ -76824,11 +76892,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/upper)
 "qat" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/smooth,
 /area/medical/morgue)
 "qay" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -77040,21 +77108,18 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/captain/private)
 "qdH" = (
-/obj/structure/table/wood,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Space Suit 2 - Medbay ";
-	dir = 6;
-	name = "Camera"
-	},
-/turf/open/floor/plating,
-/area/maintenance/external/port)
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/siding/blue/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "qdI" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/firealarm/directional/north,
@@ -77127,18 +77192,11 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "qdW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/holopad,
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "qez" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -77408,6 +77466,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"qgB" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/cmo)
 "qgJ" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -77431,6 +77495,20 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"qgP" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/sign/warning/coldtemp{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/medical/treatment_center)
 "qgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -77554,7 +77632,7 @@
 /area/solars/starboard/aft)
 "qir" = (
 /turf/closed/wall/r_wall,
-/area/medical/surgery)
+/area/medical/break_room)
 "qiA" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -77893,6 +77971,13 @@
 	dir = 8
 	},
 /area/hallway/primary/starboard)
+"qmO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "qmQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 1
@@ -78036,6 +78121,12 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"qnZ" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "qoa" = (
 /turf/closed/wall,
 /area/maintenance/fore/upper)
@@ -78077,14 +78168,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard/aft)
-"qoA" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "surgerya";
-	name = "privacy shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/pharmacy)
 "qoV" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/dirt,
@@ -78497,20 +78580,22 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "qsK" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/blue/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/medical/break_room)
 "qsQ" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
@@ -78606,7 +78691,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qvk" = (
@@ -79341,6 +79426,15 @@
 	},
 /turf/open/floor/plating,
 /area/solars/starboard/fore)
+"qCj" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron{
+	base_icon_state = "freezerfloor";
+	icon_state = "freezerfloor"
+	},
+/area/medical/treatment_center)
 "qCn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/yellow{
@@ -79402,23 +79496,17 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "qCQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/siding/blue,
+/obj/machinery/camera{
+	c_tag = "Medbay - Main Hall 4";
+	dir = 1;
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
+/obj/structure/window/spawner/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qCW" = (
@@ -79511,16 +79599,12 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "qDX" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/vehicle/ridden/wheelchair,
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qDY" = (
@@ -80247,6 +80331,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/theater)
+"qNA" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "qNO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -80288,16 +80382,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "qOC" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/paramedic,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
 "qOU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -80559,24 +80652,11 @@
 	},
 /area/maintenance/starboard/aft)
 "qRR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light/directional/west,
-/obj/machinery/button/door/directional/west{
-	id = "surgeryc";
-	name = "Privacy Shutters Control";
-	pixel_y = 23
-	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/end{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_c)
+/area/medical/storage)
 "qSd" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/safe)
@@ -80713,12 +80793,14 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "qUb" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
 "qUi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
@@ -80727,8 +80809,20 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "qUp" = (
-/turf/closed/wall,
-/area/medical/surgery/room_b)
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/wallframe/defib_mount,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/structure/cable,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/white/textured,
+/area/medical/storage)
 "qUt" = (
 /obj/effect/turf_decal/stripes/red/box,
 /obj/machinery/door/airlock/external/glass{
@@ -80985,6 +81079,15 @@
 /obj/item/clothing/glasses/sunglasses/big,
 /turf/open/floor/carpet/royalblue,
 /area/service/lawoffice)
+"qXK" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white/textured_corner{
+	dir = 8
+	},
+/area/medical/treatment_center)
 "qXS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -81528,13 +81631,12 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "rct" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medical Storage";
-	req_access_txt = "45"
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "rcx" = (
 /obj/structure/sign/poster/contraband/lizard,
 /turf/closed/wall,
@@ -82160,12 +82262,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "rkO" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "rkQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -82182,13 +82283,17 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "rkT" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/suit_storage_unit/cmo,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/command/heads_quarters/cmo)
 "rkX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -82214,6 +82319,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"rlO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/external/port)
 "rlP" = (
 /mob/living/simple_animal/pet/penguin/baby,
 /turf/open/floor/holofloor/beach/coast_t{
@@ -82444,14 +82555,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -82477,6 +82585,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"roM" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/rxglasses{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/chem_pack{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron/white/smooth_corner,
+/area/medical/treatment_center)
 "roP" = (
 /obj/machinery/keycard_auth{
 	pixel_x = -26;
@@ -82746,7 +82867,9 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "rrY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rsb" = (
@@ -83050,6 +83173,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/storage/tcomms)
+"rvY" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "rwf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/loot_site_spawner,
@@ -83089,6 +83223,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/royalblue,
 /area/service/lawoffice)
+"rwJ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/external/port)
 "rwQ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Science SMES Access";
@@ -83626,6 +83767,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage_shared)
+"rDb" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/medical/patients_rooms)
 "rDf" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -83722,10 +83877,16 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "rEo" = (
 /obj/structure/table/glass,
-/obj/item/stamp/cmo,
-/obj/item/clothing/neck/stethoscope,
+/obj/machinery/computer/med_data/laptop,
+/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
@@ -83968,6 +84129,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"rHt" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/white/textured_corner{
+	dir = 1
+	},
+/area/medical/treatment_center)
 "rHA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -84121,14 +84296,12 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
 "rIR" = (
-/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/vehicle/ridden/wheelchair,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rIY" = (
@@ -84219,13 +84392,15 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "rKc" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/blue/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/siding/blue,
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/obj/structure/window/spawner/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rKl" = (
@@ -84253,11 +84428,8 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "rKM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/medical_doctor,
+/obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "rKO" = (
@@ -84329,14 +84501,20 @@
 /area/hallway/primary/fore)
 "rLy" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/blue{
+/obj/structure/table/glass,
+/obj/item/storage/box/bodybags{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/masks,
+/obj/item/blood_filter,
+/obj/item/blood_filter,
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
-/area/medical/pharmacy)
+/area/medical/storage)
 "rLE" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -84765,7 +84943,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/obj/machinery/computer/camera_advanced/base_construction,
+/obj/machinery/computer/camera_advanced/base_construction/aux,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "rRj" = (
@@ -84818,13 +84996,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "rRK" = (
-/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/chair,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rRN" = (
@@ -85041,15 +85219,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"rVi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
 "rVk" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/cargo_technician,
@@ -85136,21 +85305,13 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/space/nearstation)
 "rWf" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "surgery";
+	name = "privacy shutters"
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical{
-	name = "Recovery Room"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/plating,
+/area/medical/surgery)
 "rWk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -85275,15 +85436,20 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "rYo" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/chief_medical_officer,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "rYt" = (
@@ -85814,6 +85980,23 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"sfq" = (
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/glass/bottle/formaldehyde,
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = 6
+	},
+/obj/item/storage/belt/medical,
+/obj/structure/table/glass,
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/medical/treatment_center)
 "sfy" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -86006,6 +86189,13 @@
 	},
 /turf/open/floor/circuit/red,
 /area/science/robotics/mechbay)
+"siE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "siF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -86948,31 +87138,40 @@
 /turf/open/floor/plating/rust,
 /area/hallway/primary/upper)
 "srE" = (
-/obj/structure/table/glass,
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/structure/window/spawner,
-/obj/structure/window/spawner/east,
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
+/obj/structure/sign/poster/official/help_others{
+	pixel_x = -32
 	},
-/obj/item/blood_filter,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/computer/operating{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge{
+	dir = 4
+	},
+/area/medical/surgery)
 "srF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "srK" = (
-/obj/effect/spawner/randomcolavend,
-/obj/structure/fluff/broken_flooring{
-	dir = 8;
-	icon_state = "pile"
+/obj/structure/window/reinforced/tinted{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/medical/patients_rooms)
 "srN" = (
 /obj/machinery/exodrone_launcher,
 /obj/item/exodrone,
@@ -87118,6 +87317,17 @@
 	dir = 8
 	},
 /area/maintenance/starboard/aft)
+"stJ" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "stM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -87592,23 +87802,12 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
 "sAe" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera{
-	c_tag = "Medbay - Resting Room";
-	dir = 4;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/surgery)
 "sAg" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
@@ -87840,10 +88039,13 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "sDi" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "sDj" = (
@@ -87872,8 +88074,15 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "sDI" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/medical/storage)
 "sDN" = (
 /obj/structure/table/reinforced,
 /obj/item/hand_labeler,
@@ -88257,11 +88466,10 @@
 	},
 /area/maintenance/starboard/aft)
 "sIF" = (
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = 32
-	},
-/turf/closed/wall,
-/area/medical/treatment_center)
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/blue,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "sIM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -88319,15 +88527,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/solars/aux/port)
-"sIY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
 "sJc" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/computer/security/telescreen{
@@ -88420,15 +88619,12 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "sJJ" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/effect/turf_decal/siding/blue,
-/obj/machinery/door/window/southleft{
-	dir = 8;
-	name = "Medbay Delivery";
-	req_access_txt = "5"
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/dark,
 /area/medical/morgue)
 "sJT" = (
 /obj/structure/lattice,
@@ -88744,6 +88940,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"sMZ" = (
+/obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/cmo)
 "sNi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 6
@@ -89047,12 +89253,21 @@
 /turf/open/floor/wood,
 /area/service/library)
 "sQN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/plating,
-/area/maintenance/external/port)
+/obj/effect/turf_decal/siding/blue/corner,
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "sRb" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light/directional/south,
@@ -89270,23 +89485,15 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "sTl" = (
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire,
-/obj/structure/window/spawner/west,
-/obj/structure/window/spawner,
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/computer/operating,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/fire,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_edge,
+/area/medical/surgery)
 "sTr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/machinery/door/window/westright{
@@ -89702,7 +89909,7 @@
 "sZo" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
-/area/medical/surgery)
+/area/medical/break_room)
 "sZq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -89948,9 +90155,14 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "tbF" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/siding/blue,
-/turf/open/floor/iron/white,
+/obj/effect/landmark/start/paramedic,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/medical/morgue)
 "tbJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
@@ -89964,6 +90176,21 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"tbV" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "tcm" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 1
@@ -90082,10 +90309,8 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "tdy" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/smooth_corner,
 /area/medical/morgue)
 "tdC" = (
 /obj/effect/turf_decal/tile/blue,
@@ -90505,6 +90730,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
+"tjC" = (
+/obj/machinery/requests_console/directional/south{
+	department = "Medbay Surgery";
+	name = "Surgery RC"
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "tjD" = (
 /obj/structure/bed/nest,
 /obj/machinery/light/small/directional/west,
@@ -90596,11 +90828,9 @@
 /area/service/hydroponics/garden)
 "tkp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/siding/blue/corner,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -90795,11 +91025,14 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "tno" = (
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/storage/pill_bottle/mannitol,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "tnD" = (
@@ -90840,7 +91073,7 @@
 /area/command/heads_quarters/hop)
 "tnV" = (
 /turf/closed/wall/r_wall,
-/area/medical/surgery/room_c)
+/area/medical/storage)
 "toe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -91039,32 +91272,17 @@
 /turf/open/floor/mineral/titanium/white,
 /area/maintenance/starboard/aft)
 "tqz" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/glass/bottle/multiver{
-	pixel_x = 6
-	},
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
-	},
+/obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/item/storage/firstaid,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/belt/medical,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured_edge,
 /area/medical/treatment_center)
 "tqP" = (
 /obj/machinery/button/door/directional/east{
@@ -91186,6 +91404,18 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"tsA" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "tsB" = (
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
@@ -91307,6 +91537,11 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"tuD" = (
+/obj/structure/cable,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "tuF" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/siding/red{
@@ -92261,22 +92496,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"tFe" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay - Examination Storage";
-	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "tFh" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -92452,6 +92671,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"tHR" = (
+/obj/effect/spawner/randomcolavend,
+/obj/structure/fluff/broken_flooring{
+	dir = 8;
+	icon_state = "pile"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "tHS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93250,6 +93477,13 @@
 	},
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard/aft)
+"tQz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "tQE" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/tile/purple,
@@ -93397,19 +93631,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "tSe" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/item/bedsheet/medical,
-/obj/structure/bed,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/surgery)
 "tSn" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -93723,15 +93949,11 @@
 /turf/open/floor/bluespace,
 /area/hallway/secondary/service)
 "tUy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "tUD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -93866,14 +94088,12 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "tWn" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/effect/turf_decal/tile/blue,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/surgery)
 "tWr" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1
@@ -94123,17 +94343,6 @@
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"ubk" = (
-/obj/vehicle/ridden/wheelchair,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "ubp" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window/reinforced{
@@ -94269,27 +94478,15 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "udk" = (
-/obj/structure/cable,
-/obj/structure/fluff/broken_flooring{
-	dir = 4;
-	icon_state = "pile"
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard/aft)
-"udn" = (
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 38
-	},
-/obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
+"udn" = (
+/obj/structure/sign/poster/random,
+/turf/closed/wall,
+/area/medical/morgue)
 "udq" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/west,
@@ -94674,11 +94871,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "uge" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "ugh" = (
 /obj/structure/chair/stool,
 /obj/structure/cable,
@@ -94965,27 +95164,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"uiD" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/storage/belt/medical,
-/obj/item/wallframe/defib_mount,
-/obj/item/wallframe/defib_mount,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "uiJ" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 8;
@@ -95330,30 +95508,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"unG" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers,
-/obj/item/reagent_containers/glass/bottle/formaldehyde,
-/obj/item/reagent_containers/glass/bottle/multiver{
-	pixel_x = 6
-	},
-/obj/item/storage/firstaid,
-/obj/item/storage/belt/medical,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "unJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -95428,6 +95582,10 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/light_switch/directional/east{
+	pixel_x = 38
 	},
 /turf/open/floor/plating,
 /area/maintenance/external/port)
@@ -96172,6 +96330,14 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/aisat_interior)
+"uwA" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/white/textured_edge,
+/area/medical/treatment_center)
 "uwM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment,
@@ -96258,6 +96424,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"uxr" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/cmo)
 "uxs" = (
 /obj/structure/closet/emcloset,
 /obj/item/radio/intercom/directional/east{
@@ -97153,8 +97335,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/siding/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/effect/turf_decal/siding/blue/corner,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uHo" = (
@@ -97647,18 +97830,19 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/space/nearstation)
 "uMw" = (
-/obj/structure/bed/roller,
 /obj/structure/sign/warning/bodysposal{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/siding/blue{
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
 /area/medical/morgue)
 "uMJ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -97782,7 +97966,7 @@
 	pixel_x = 32
 	},
 /turf/closed/wall,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
 "uNT" = (
 /obj/effect/turf_decal/siding/yellow/end{
 	dir = 1
@@ -98194,7 +98378,16 @@
 /area/hallway/primary/port)
 "uTd" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
 /area/medical/morgue)
 "uTi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -98513,6 +98706,15 @@
 /obj/structure/sign/poster/random,
 /turf/closed/wall,
 /area/maintenance/port/central)
+"uWh" = (
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "uWn" = (
 /obj/machinery/mechpad,
 /obj/effect/turf_decal/siding/purple,
@@ -98687,9 +98889,14 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tcomms)
 "uYf" = (
-/obj/structure/sign/departments/examroom,
-/turf/closed/wall,
-/area/medical/treatment_center)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/smooth_edge{
+	dir = 8
+	},
+/area/medical/morgue)
 "uYq" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -99954,7 +100161,14 @@
 /area/security/detectives_office)
 "vlA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -100169,6 +100383,17 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"voB" = (
+/obj/structure/cable,
+/obj/machinery/light/directional/east,
+/obj/structure/fluff/broken_flooring{
+	dir = 8;
+	icon_state = "pile"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/aft)
 "voD" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -100316,6 +100541,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"vqj" = (
+/obj/effect/turf_decal/trimline/blue/corner,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "vqq" = (
 /obj/structure/railing{
 	dir = 9;
@@ -100416,13 +100645,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "vra" = (
-/obj/effect/turf_decal/siding/blue/corner,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "vrc" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 1
@@ -100486,13 +100710,22 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/upper)
-"vsa" = (
-/obj/machinery/light/directional/west,
-/obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/siding/blue{
+"vrO" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 1
+	},
+/area/medical/treatment_center)
+"vsa" = (
+/obj/structure/bed/roller,
+/obj/effect/turf_decal/siding/blue{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/medical/morgue)
 "vsk" = (
 /obj/machinery/door/window/westleft{
@@ -100531,11 +100764,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
 	req_access_txt = "5;6;45"
@@ -100545,23 +100773,27 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/morgue)
 "vtd" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"vtt" = (
+/obj/structure/cable,
+/obj/structure/fluff/broken_flooring,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/aft)
 "vtv" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -100788,21 +101020,14 @@
 	},
 /area/maintenance/starboard/aft)
 "vvV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
 /obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
+	name = "Surgery Room";
+	req_access_txt = "45"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "vvX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/purple{
@@ -101144,8 +101369,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "vAe" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/closet/firecloset/full,
+/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "vAj" = (
@@ -101248,7 +101476,7 @@
 /area/command/bridge)
 "vAO" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating,
 /area/medical/medbay/central)
 "vAQ" = (
 /obj/structure/cable,
@@ -101597,20 +101825,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vFQ" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "vFV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -101930,29 +102151,29 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vKk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vKE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge,
 /area/medical/morgue)
 "vKF" = (
 /obj/effect/turf_decal/tile,
@@ -102043,18 +102264,20 @@
 /area/engineering/break_room)
 "vLO" = (
 /obj/machinery/door/airlock/medical{
-	name = "Break Room";
+	name = "Patient Observation";
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/siding/blue,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
 "vLU" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -102241,16 +102464,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/upper)
 "vNq" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron{
+	base_icon_state = "freezerfloor";
+	icon_state = "freezerfloor"
 	},
-/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "vNu" = (
 /obj/structure/grille,
@@ -102925,16 +103146,26 @@
 /turf/closed/wall,
 /area/hallway/primary/aft)
 "vVF" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
-	},
 /obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/bedsheetbin,
+/obj/item/toy/plush/moth,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay - Patient's Room";
+	dir = 4;
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
 "vVR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -102953,6 +103184,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/service/bar/atrium)
+"vVV" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "vVX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
@@ -103149,13 +103386,21 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"vXX" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
+"vXK" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"vXX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -103181,22 +103426,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard/aft)
-"vYv" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "vYB" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /obj/machinery/door/firedoor,
@@ -103266,6 +103495,19 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/command/gateway)
+"wai" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/camera{
+	c_tag = "Medbay - Freezer Storage";
+	dir = 6;
+	name = "medbay camera";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white/textured_corner,
+/area/medical/treatment_center)
 "wak" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -103418,10 +103660,10 @@
 /area/engineering/engine_smes)
 "wcY" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/morgue)
 "wdd" = (
 /obj/structure/cable,
@@ -103444,17 +103686,19 @@
 /turf/closed/wall/r_wall,
 /area/science/genetics)
 "wdu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -103506,13 +103750,11 @@
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/ai_upload)
 "wec" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/machinery/vending/drugs,
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "weh" = (
 /obj/structure/cable,
 /obj/structure/fluff/broken_flooring{
@@ -103596,6 +103838,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/departments/examroom{
+	pixel_x = 32
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wfA" = (
@@ -103613,6 +103858,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
+/obj/structure/window/spawner/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wfM" = (
@@ -103863,32 +104112,11 @@
 "wiE" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/wallframe/defib_mount,
-/obj/item/wallframe/defib_mount,
-/obj/item/storage/belt/medical,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "wiP" = (
 /obj/structure/cable,
 /obj/machinery/computer/holodeck{
@@ -104723,18 +104951,13 @@
 /turf/open/floor/carpet/black,
 /area/service/theater)
 "wsK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/landmark/start/paramedic,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "wsP" = (
@@ -104798,6 +105021,23 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/carpet/black,
 /area/service/theater)
+"wub" = (
+/obj/machinery/requests_console/directional/north{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer's RC";
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/cmo)
 "wuc" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/stripes/line,
@@ -105319,13 +105559,12 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "wBa" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue";
+	req_access_txt = "5"
 	},
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 38
-	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "wBc" = (
@@ -105352,14 +105591,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "wBy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
+	},
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -105440,11 +105680,11 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "wBX" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
+/obj/machinery/medical_kiosk,
+/turf/open/floor/iron/white/smooth_corner{
+	dir = 8
+	},
 /area/medical/treatment_center)
 "wBY" = (
 /obj/structure/window/reinforced{
@@ -105798,14 +106038,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/upper)
 "wGh" = (
-/obj/machinery/door/airlock{
-	name = "Medbay Auxiliary Storage";
-	req_access_txt = "5"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
 	},
-/area/maintenance/starboard/aft)
+/area/medical/morgue)
 "wGq" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Prep";
@@ -106032,13 +106272,11 @@
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
 "wJx" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "surgeryb";
-	name = "privacy shutters"
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical/pharmacy)
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "wJy" = (
 /obj/effect/turf_decal/tile{
 	dir = 4
@@ -107273,15 +107511,11 @@
 	},
 /area/maintenance/starboard/aft)
 "wXm" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/sign/warning/coldtemp{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 6
-	},
-/obj/vehicle/ridden/wheelchair,
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "wXy" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/command)
@@ -107608,24 +107842,6 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "xbq" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/landmark/start/chief_medical_officer,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/requests_console/directional/north{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer's RC";
-	pixel_x = -30;
-	pixel_y = 0
-	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "xbu" = (
@@ -107949,19 +108165,10 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/fore)
 "xgc" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/suit_storage_unit/cmo,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "xge" = (
@@ -108034,13 +108241,18 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xgL" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
+/obj/structure/bodycontainer/morgue{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_edge{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
 /area/medical/morgue)
 "xgM" = (
 /obj/structure/cable,
@@ -108129,23 +108341,14 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "xhl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/door/airlock/command{
-	name = "Chief Medical Officer's Office";
-	req_access_txt = "40"
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/white,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cmoshutter";
+	name = "CMO Office Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
 "xhn" = (
 /obj/effect/turf_decal/tile/green{
@@ -108541,30 +108744,18 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "xlF" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
 	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/multiver{
-	pixel_x = 6
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/stack/medical/mesh,
-/obj/item/reagent_containers/glass/bottle/multiver{
-	pixel_x = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
 	},
-/obj/item/reagent_containers/glass/bottle/formaldehyde,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/syringe,
-/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "xlG" = (
@@ -108790,34 +108981,26 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "xnW" = (
-/obj/item/storage/box/bodybags,
-/obj/structure/table,
-/obj/item/storage/bag/bio,
-/obj/effect/turf_decal/siding/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/table/optable,
+/turf/open/floor/iron/dark,
 /area/medical/morgue)
 "xnY" = (
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "xoa" = (
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "xoh" = (
@@ -109194,28 +109377,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "xsR" = (
-/obj/structure/table/glass,
-/obj/item/gun/syringe,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/masks,
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/surgery)
 "xsV" = (
 /obj/structure/cable,
 /obj/machinery/power/emitter,
@@ -109915,6 +110080,13 @@
 /obj/machinery/newscaster,
 /turf/closed/wall/r_wall,
 /area/hallway/primary/starboard)
+"xyv" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "xyC" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -109978,13 +110150,9 @@
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard/aft)
 "xzs" = (
-/obj/structure/table/glass,
-/obj/item/folder/white,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/storage/pill_bottle/mannitol,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -110015,11 +110183,12 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "xzR" = (
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -110305,6 +110474,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"xBW" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/white/textured_corner{
+	dir = 4
+	},
+/area/medical/treatment_center)
 "xCb" = (
 /obj/structure/chair/stool,
 /turf/open/floor/iron,
@@ -110530,11 +110714,20 @@
 /turf/closed/wall,
 /area/science/server)
 "xEO" = (
-/obj/effect/turf_decal/siding/blue{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/white/side,
+/area/medical/break_room)
 "xEW" = (
 /obj/structure/closet,
 /obj/machinery/light/directional/west,
@@ -111448,21 +111641,14 @@
 /area/engineering/atmos)
 "xMI" = (
 /obj/machinery/stasis,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/defibrillator_mount/directional/north,
+/turf/open/floor/iron/white/textured_edge,
 /area/medical/treatment_center)
 "xMJ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -111529,19 +111715,18 @@
 /turf/open/floor/plating,
 /area/medical/pharmacy)
 "xNE" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 38
+/obj/machinery/button/door/directional/west{
+	id = "surgery";
+	name = "Privacy Shutters Control";
+	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/surgery)
 "xNG" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/north,
@@ -111891,16 +112076,15 @@
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "xRp" = (
-/obj/effect/turf_decal/siding/blue{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/patients_rooms)
 "xRq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -112084,15 +112268,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/stellar,
 /area/commons/dorms)
-"xTk" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "surgerya";
-	name = "privacy shutters"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/medical/surgery/room_c)
 "xTl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -112490,7 +112665,7 @@
 /area/medical/chemistry)
 "xZt" = (
 /turf/closed/wall,
-/area/medical/pharmacy)
+/area/medical/storage)
 "xZG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating{
@@ -112522,15 +112697,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/upper)
 "xZY" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/structure/window/reinforced/tinted,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron/white/textured,
+/area/medical/patients_rooms)
 "yab" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
@@ -112608,8 +112785,17 @@
 /turf/open/floor/carpet/black,
 /area/service/theater)
 "yaY" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -112764,6 +112950,14 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engineering/engine_smes)
+"ydt" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Storage";
+	req_access_txt = "45"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ydz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 1
@@ -113298,15 +113492,20 @@
 /turf/open/floor/carpet/blue,
 /area/maintenance/starboard/aft)
 "ykZ" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/blue{
+/obj/machinery/light_switch/directional/east{
+	pixel_x = 38
+	},
+/obj/machinery/computer/operating{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white/textured_edge{
+	dir = 8
+	},
+/area/medical/surgery)
 "ylf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -152858,7 +153057,7 @@ rcT
 cSn
 hHK
 hMO
-kYL
+enl
 jkU
 pqf
 bxp
@@ -160797,16 +160996,16 @@ tYx
 tYx
 tYx
 tYx
-tYx
-tYx
-tYx
-wVi
-tYx
-tYx
-tYx
-hLS
+fvU
+fvU
+fvU
+udn
+fvU
+fEQ
+fvU
+fvU
 dlm
-wJT
+fvU
 bMz
 wJT
 wUM
@@ -161062,8 +161261,8 @@ oWI
 nPN
 vsa
 ioc
-wUM
-ibk
+dcJ
+fvU
 bMA
 aKA
 nTE
@@ -161311,16 +161510,16 @@ rXk
 uAA
 xSf
 lza
-wdL
+fvU
 kHA
 tdy
-hmT
-tdy
+uYf
+wGh
 uTd
 wcY
 sJJ
+fKe
 fvU
-sQN
 mLb
 kGg
 hBO
@@ -161574,16 +161773,16 @@ hmT
 qat
 vKE
 ahC
-hmT
+elt
 xnW
-wUM
-qdH
+feE
+fvU
 bwD
 fCs
 vAe
-sYw
-qJO
-qJO
+hmF
+gCq
+vNK
 qJO
 qJO
 qJO
@@ -161831,16 +162030,16 @@ eVy
 mCZ
 nYN
 gnP
-tdy
+qnZ
 tbF
-wUM
-pFC
+kQk
+fvU
 kpz
 kGg
-ixj
-sYw
-qJO
-qJO
+kGg
+kGg
+rlO
+vNK
 qJO
 qJO
 qJO
@@ -162086,7 +162285,7 @@ fvU
 fxy
 kvr
 xgL
-lWu
+xgL
 hhC
 edD
 aCh
@@ -162095,9 +162294,9 @@ wBa
 nKF
 uoj
 peX
-sYw
-qJO
-qJO
+rwJ
+ozO
+vNK
 qJO
 qJO
 qJO
@@ -162340,20 +162539,20 @@ wdL
 qxZ
 bgG
 viX
-fce
 fvU
-ncN
+fvU
+fvU
 nTV
 vsU
 fvU
+lWp
 fvU
-wUM
-wUM
+fvU
 tSw
 sYw
 sYw
 sYw
-vwu
+sYw
 vwu
 vwu
 vwu
@@ -163115,7 +163314,7 @@ rOY
 tJT
 hCO
 pOA
-hCO
+eVM
 bxQ
 tkp
 wfg
@@ -163370,12 +163569,12 @@ fsc
 lPa
 siO
 mPG
-uYf
 rsb
-eqy
+rsb
+rsb
 gKo
 eqy
-mwM
+rsb
 rsb
 rsb
 kmP
@@ -163623,23 +163822,23 @@ omB
 nHG
 ibC
 akl
-atl
+fsc
 rIR
 wQK
-xDx
+neq
 rsb
 naG
 iHt
 dzl
 gal
 vNq
-hwQ
-unG
-kmP
-ccX
-ccX
-ccW
-vwu
+vNq
+vNq
+acP
+nCI
+jYu
+sfq
+jNj
 udX
 ody
 jNj
@@ -163878,25 +164077,25 @@ hKL
 qir
 xEO
 gls
-gls
+exc
 qsK
 nAG
 rop
 pVN
-mPG
-sIF
-kNr
+osE
+rsb
+xMI
 wBy
 jZq
 yaY
-oOu
+xlF
 iXZ
 xlF
-kmP
-aae
-aae
-ccX
-vwu
+tbV
+uWh
+iro
+jVF
+jNj
 mOc
 hWg
 jNj
@@ -164137,23 +164336,23 @@ nqw
 ozr
 oHU
 phq
-sZo
-neB
+fsc
+rIR
 qfl
 oNW
-eqy
+rsb
 gZE
 heC
 aWD
 ioI
-yaY
 sDi
-lNb
-kmP
-ccW
-ccW
-ccX
-vwu
+sDi
+sDi
+iry
+qmO
+siE
+vrO
+jNj
 hPe
 myr
 jNj
@@ -164389,12 +164588,12 @@ saq
 bwH
 cbD
 eXc
-hKL
+tnV
 xZt
-qoA
-qoA
-qoA
-ola
+xZt
+fVi
+xZt
+xZt
 nmO
 oWz
 aor
@@ -164403,13 +164602,13 @@ vKk
 wdu
 ePY
 fol
-oOu
-iXZ
+roM
+mMG
 iHy
-kmP
-aae
-ccX
-ccW
+fWq
+vVV
+vXK
+bXL
 vwu
 vwu
 vwu
@@ -164649,7 +164848,7 @@ mDH
 fEZ
 hoW
 rLy
-rLy
+gml
 dFH
 oLK
 vtd
@@ -164663,11 +164862,11 @@ oBx
 wBX
 rkO
 mUx
+fWq
+tQz
+iyJ
+gEX
 kmP
-aae
-ccX
-ccX
-ccX
 ccX
 ccW
 vwu
@@ -164903,12 +165102,12 @@ hrX
 nMk
 mwt
 iqg
-hKL
+dQp
+mwu
+wJx
+hLS
+ith
 xZt
-wJx
-wJx
-wJx
-ola
 ssD
 wQK
 oQP
@@ -164919,12 +165118,12 @@ hAo
 djE
 lbr
 bnp
-gHd
+lbr
+iqM
+hpo
+ltJ
+gyO
 kmP
-ccW
-ccX
-ccW
-ccW
 ccX
 ccW
 vwu
@@ -165160,7 +165359,7 @@ bia
 ofz
 gvo
 eRR
-khg
+tnV
 nJD
 mQW
 oSi
@@ -165177,11 +165376,11 @@ wsK
 hsz
 vlA
 pwz
+tsA
+ata
+rvY
+jVF
 kmP
-ccW
-aae
-aae
-ccW
 ccX
 ccW
 vwu
@@ -165417,10 +165616,10 @@ kwf
 ycT
 beF
 qYX
-khg
+tnV
 pla
 sDI
-sDI
+hLS
 pxf
 pnl
 pBQ
@@ -165434,11 +165633,11 @@ ftp
 lKu
 hYg
 kFG
+bVT
+xyv
+qNA
+qgP
 kmP
-aae
-ccW
-aae
-aae
 ccX
 ccX
 vwu
@@ -165674,7 +165873,7 @@ tcm
 dzn
 bfh
 oEN
-khg
+tnV
 pdD
 jjy
 hSn
@@ -165691,11 +165890,11 @@ fbZ
 ldS
 ldS
 ldS
-haa
-aae
-ccW
-aae
-ccX
+ldS
+rsb
+onB
+rsb
+kmP
 ccW
 ccX
 vwu
@@ -165931,28 +166130,28 @@ pLZ
 nDh
 dUG
 eYV
-khg
+tnV
 qUp
 kFL
-kFL
-kFL
-cdw
+ibk
+ixj
+cEl
 rRK
 wQK
 wfG
 ldS
 sTl
 wiE
-elx
+vra
 jfv
 oIh
 kDY
 srE
-haa
-ccW
-ccX
-ccW
-ccX
+ldS
+wai
+xBW
+fhG
+kmP
 ccW
 ccX
 vwu
@@ -166193,23 +166392,23 @@ qRR
 mwu
 aum
 mVW
-efN
+xZt
 jbS
 pVN
-xDx
+neq
 ldS
 lyQ
 uge
 qdW
 tUy
-ubk
-uge
+wec
+oaQ
 wec
 hJd
-ccX
-aae
-aae
-aae
+kGh
+uwA
+qCj
+kmP
 ccW
 ccX
 vwu
@@ -166450,23 +166649,23 @@ gwd
 jSH
 meG
 boW
-xTk
+xZt
 oeY
 wQK
-mPG
+pFC
 ldS
 kfZ
 gvq
-hBB
-gvq
-ons
+vra
+vra
+vra
 vra
 wXm
-haa
-ccW
-ccW
-aae
-aae
+ldS
+qXK
+rHt
+kbq
+kmP
 aae
 ccX
 vwu
@@ -166703,8 +166902,8 @@ gsu
 sgV
 nUP
 tnV
-pQp
-fce
+xZt
+xZt
 mzl
 gMg
 lMp
@@ -166714,16 +166913,16 @@ aVh
 ldS
 kFM
 kgA
-tFe
 xsR
-uiD
+xsR
+xsR
 vFQ
-fce
-hJd
-gZT
-gZT
-gZT
-ccW
+hPJ
+hPJ
+hPJ
+hPJ
+hPJ
+gcQ
 aae
 ccW
 vwu
@@ -166967,20 +167166,20 @@ xHx
 ppo
 ybp
 ukN
-mPG
+qdH
 gZg
-fgK
-fgK
-fgK
-fgK
-fgK
+xNE
+oHD
+oal
+tjC
+hPJ
 vLO
-fce
+hPJ
 cTB
 hSw
 vVF
-gZT
-ccW
+oDM
+gcQ
 ccW
 ccW
 vwu
@@ -167220,26 +167419,26 @@ gZT
 tKI
 mcP
 gIM
-ith
+mMh
 fgK
 ars
 mca
-rKc
+xDx
 rWf
-knm
+tSe
 sAe
 tSe
 tWn
 uNO
-vYv
+xRp
 xRp
 qOC
 dZs
-mLi
-gZT
+qOC
+stJ
+gcQ
 cOg
 cOg
-ccW
 vwu
 nQQ
 nFP
@@ -167481,22 +167680,22 @@ diW
 ozz
 deY
 xwk
-gml
-fgK
-ssD
-jXn
+mPG
+rWf
+ykZ
+cdI
 hSE
 aVj
-fce
+hPJ
 kQF
 qUb
 oPv
-qUb
+vqj
 pAj
 rct
+ydt
 vht
-cOg
-ccW
+tmw
 vwu
 vwu
 vwu
@@ -167735,29 +167934,29 @@ tno
 xVo
 rrY
 uHj
-fgK
-pOL
+kYL
+ncN
 wQK
-xDx
-fgK
-xNE
-udn
-dQp
-osE
-fce
+qCQ
+vZk
+vZk
+vZk
+vZk
+vZk
+lgd
 dFg
 xZY
-pwl
-kIO
+udk
+oOe
 dPq
-fce
+eZj
+hPJ
 vht
-oaN
-ccX
-aae
-ccW
-ccW
-aae
+tmw
+aAJ
+gdV
+gig
+vtt
 vwu
 wcK
 lIY
@@ -167992,29 +168191,29 @@ xzs
 xVo
 igj
 mMh
-iNi
-pUY
-qCQ
-biQ
+ppo
+qDX
+wQK
+rKc
+vZk
+uxr
+sMZ
+aIT
+wub
 vZk
 vZk
-vZk
-vZk
-vZk
-vZk
-gZT
-oaN
-oaN
-iGL
-iGL
-oaN
+srK
+udk
+oOe
+rDb
+hPJ
+hPJ
 vht
+dzc
 oaN
-ccW
-ccW
-ccX
-ccX
-ccW
+tHR
+tuD
+lJH
 vwu
 qAS
 pWB
@@ -168251,27 +168450,27 @@ hmm
 qkz
 gZT
 cZm
-exc
-cZm
-oiw
+wQK
+sIF
+vZk
 eaE
-jha
+xbq
 fAX
 xbq
 mkd
-cOg
+vZk
 mCL
 udk
-luU
-lBy
+oOe
+gMt
+hPJ
 vht
 vht
-oaN
+jTp
 iGL
-aae
-ccW
-ccX
-ccW
+hFj
+voB
+bkW
 vwu
 hls
 wZM
@@ -168504,9 +168703,9 @@ xLE
 gZT
 gZT
 vAO
+vAO
 gZT
 gZT
-qYX
 qDX
 fjQ
 gFu
@@ -168516,19 +168715,19 @@ beH
 rEo
 rYo
 mar
-cOg
+vZk
 srK
-kxr
-enN
-iGL
-oaN
+udk
+oOe
+rDb
+hPJ
 owp
 dzc
 oaN
 oaN
 oaN
 oaN
-ccW
+oaN
 vwu
 vwu
 vwu
@@ -168761,7 +168960,7 @@ tRg
 mDV
 oxl
 oPj
-ykZ
+bfh
 aDy
 leg
 pOL
@@ -168769,19 +168968,19 @@ ndM
 oXl
 xhl
 ofk
-sIY
+xbq
 fBD
-rVi
+xbq
 fdF
 vZk
-kBQ
+mCL
 lSY
 oOe
-iGL
-vAQ
+gMt
+hPJ
 vht
-tmw
-tmw
+vht
+mtO
 cir
 utp
 oaN
@@ -169023,22 +169222,22 @@ raf
 pfO
 ssD
 wQK
-mPG
+sQN
 oiw
 elk
 xoa
 bob
 xgc
 fyY
-cOg
-iGL
-iGL
-lrB
-iGL
-vAQ
-oaN
-neq
-jnJ
+vZk
+hPJ
+hPJ
+cTF
+hPJ
+hPJ
+dzc
+flc
+ovg
 vvI
 dzc
 oaN
@@ -169280,22 +169479,22 @@ qVK
 jkH
 uLS
 seX
-fVi
+xDx
+cPQ
+cJt
+eht
+fGV
 vZk
 vZk
 vZk
-vZk
-vZk
-vZk
-cOg
-oaN
+iiw
 uEK
-vht
+nWj
 oaN
-vht
-oaN
-iGL
 tmw
+jnJ
+iGL
+vht
 oaN
 iGL
 oaN
@@ -169539,13 +169738,13 @@ kep
 oSL
 poo
 cPQ
-tmw
-tmw
-tmw
-iGL
-lVH
+jng
+qgB
+bHY
+kzs
+dzc
 tix
-iGL
+tmw
 vht
 nrp
 gqH
@@ -169795,11 +169994,11 @@ qYX
 xnl
 oaN
 oaN
-oaN
+vZk
 rkT
 pst
-jnJ
-lrB
+csr
+oVm
 uUK
 qqu
 vht
@@ -170052,11 +170251,11 @@ cOg
 ktu
 cLQ
 pQF
-iGL
-iGL
-iGL
-wGh
-iGL
+vZk
+vZk
+vZk
+vZk
+vZk
 hNl
 caS
 qBt
@@ -170311,7 +170510,7 @@ nHV
 rcI
 aAJ
 vht
-oaN
+tmw
 nrp
 vht
 vAQ
@@ -170568,7 +170767,7 @@ yik
 nvM
 iGL
 vAQ
-cFA
+iMe
 vht
 dzc
 iGL
@@ -170828,7 +171027,7 @@ xDH
 lFs
 maZ
 vvI
-dzc
+iGL
 vht
 vht
 oaN


### PR DESCRIPTION
## Disclaimer: I do not consent to siding decals being used on my work. If you plan on adding siding decals to it, just close my pull request. If this is merged and siding decals are added to it, I'll make a revert pull request.

## About The Pull Request

Makes medbay generally nicer, cleaner, spacious and worthwhile. It surprises me that a station meant for highpop has a medbay that people have a hard time traveling around.
Also fixes things like: atmos having a varedited directional light, aux base not working, and SM having a varedited directional air alarm.

![image](https://user-images.githubusercontent.com/68669754/127759973-ab6da43a-a244-42aa-9435-dcadc492884c.png)
![image](https://user-images.githubusercontent.com/68669754/127759975-e7c8241b-9c2f-410e-9886-7ca1d4269902.png)


## Why It's Good For The Game

Medbay needed a rework. Badly. It's a mess in its current state, ranging from surgery rooms that hardly make sense, patient rooms that have little effort put into it, a exam room with even amount of tiles but uneven amount of airlocks, barely any morgue trays, and more. This fixes most of it.
Also I'm not adding sidings because they are genuinely the most awful decals.